### PR TITLE
added GYP bindings & basic windows support

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,0 +1,77 @@
+{
+  'targets': [{
+    'target_name': 'couchbase_impl',
+    'conditions': [
+      [ 'OS=="win"', {
+        'variables': {
+          'couchbase_root%': 'C:/couchbase'
+        },
+        'include_dirs': [
+          '<(couchbase_root)/include/',
+        ],
+        'link_settings': {
+          'libraries': [
+            '-l<(couchbase_root)/lib/libcouchbase.lib',
+          ],
+        },
+        'copies': [{
+          'files': [ '<(couchbase_root)/lib/libcouchbase.dll' ],
+          'destination': '<(module_root_dir)/build/Release/',
+        },],
+        'configurations': {
+          'Release': {
+            'msvs_settings': {
+              'VCCLCompilerTool': {
+                'ExceptionHandling': '2',
+                'RuntimeLibrary': 0,
+              },
+            },
+          },
+        },
+      }],
+      ['OS=="mac"', {
+        'xcode_settings': {
+          'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+        },
+      }],
+      ['OS!="win"', {
+        'link_settings': {
+          'libraries': [
+            '-lcouchbase',
+          ],
+        },
+        'cflags': [
+          '-g',
+          '-fPIC',
+          '-Wno-unused-variable',
+          '-Wno-unused-function',
+        ],
+        'cflags!': [
+          '-fno-exceptions',
+        ],
+        'cflags_cc!': [
+          '-fno-exceptions',
+        ],
+      }],
+    ],
+    'sources': [
+      'src/args.cc',
+      'src/couchbase_impl.cc',
+      'src/namemap.cc',
+      'src/notify.cc',
+      'src/operations.cc',
+      'src/cas.cc',
+      'io/common.c',
+      'io/socket.c',
+      'io/read.c',
+      'io/write.c',
+      'io/timer.c',
+      'io/plugin-libuv.c',
+      'io/util/lcb_luv_yolog.c',
+      'io/util/hexdump.c',
+    ],
+    'include_dirs': [
+      './',
+    ],
+  }]
+}

--- a/io/common.c
+++ b/io/common.c
@@ -76,7 +76,13 @@ lcb_luv_schedule_disable(lcb_luv_socket_t sock)
     sock->prep_active = 0;
 }
 
-static inline lcb_socket_t
+static
+#if _WIN32
+ __inline
+#else
+ inline
+#endif
+lcb_socket_t
 find_free_idx(struct lcb_luv_cookie_st *cookie)
 {
     lcb_socket_t ret = -1;
@@ -196,9 +202,9 @@ lcb_luv_socket_deinit(lcb_luv_socket_t sock)
     sock->idx = -1;
 
     if (sock->refcount > 1) {
+        int ii;
         log_socket_warn("Socket %p still has a reference count of %d",
                         sock, sock->refcount);
-        int ii;
         for (ii = 0; ii < LCB_LUV_EV_MAX; ii++) {
             struct lcb_luv_evstate_st *evstate = sock->evstate + ii;
             log_socket_warn("Flags for evstate@%d: 0x%X", ii, evstate->flags);
@@ -342,6 +348,9 @@ lcb_luv_errno_map(int uverr)
 #define EAISERVICE EAI_SERVICE
 #endif
 
+#ifndef EAI_SYSTEM
+#define EAI_SYSTEM -11
+#endif
 #ifndef EADDRINFO
 #define EADDRINFO EAI_SYSTEM
 #endif
@@ -356,6 +365,10 @@ lcb_luv_errno_map(int uverr)
 
 #ifndef ENONET
 #define ENONET ENETDOWN
+#endif
+
+#ifndef ESHUTDOWN
+#define ESHUTDOWN WSAESHUTDOWN
 #endif
 
 #define OK 0

--- a/io/lcb_luv_internal.h
+++ b/io/lcb_luv_internal.h
@@ -5,6 +5,13 @@
 #define LCB_LUV_YOLOG_DEBUG_LEVEL 100
 #endif
 
+#ifdef _MSC_VER
+#pragma warning(disable : 4244)
+#pragma warning(disable : 4267)
+#pragma warning(disable : 4506)
+#pragma warning(disable : 4530)
+#endif
+
 
 #include "libcouchbase-libuv.h"
 #include <stdlib.h>
@@ -13,6 +20,15 @@
 #include <assert.h>
 #include <errno.h>
 #include "util/lcb_luv_yolog.h"
+
+#ifdef UNUSED
+#elif defined(__GNUC__) 
+# define UNUSED(x) x __attribute__((unused)) 
+#elif defined(__LCLINT__) 
+# define UNUSED(x) /*@unused@*/ x 
+#else 
+# define UNUSED(x) x 
+#endif
 
 #define EVSTATE_IS(p, b) \
     ( ( (p)->flags ) & LCB_LUV_EVf_ ## b)

--- a/io/plugin-libuv.c
+++ b/io/plugin-libuv.c
@@ -2,7 +2,7 @@
 
 static int _yolog_initialized = 0;
 
-static void __attribute__((unused))
+static UNUSED(void)
 lcb_luv_noop(struct lcb_io_opt_st *iops)
 {
     (void)iops;

--- a/io/socket.c
+++ b/io/socket.c
@@ -12,7 +12,8 @@ lcb_luv_socket(struct lcb_io_opt_st *iops,
     iops->v.v0.error = EINVAL;
 
     if ( (domain != AF_INET && domain != AF_INET6) ||
-            type != SOCK_STREAM || protocol != IPPROTO_TCP)  {
+            type != SOCK_STREAM ||
+            (protocol != IPPROTO_TCP && protocol != 0))  {
         log_socket_error("Bad arguments: domain=%d, type=%d, protocol=%d",
                 domain, type, protocol);
         return -1;

--- a/io/util/hexdump.c
+++ b/io/util/hexdump.c
@@ -2,6 +2,14 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+
+#if _WIN32
+#define snprintf _snprintf
+#endif
+#ifdef _MSC_VER
+#pragma warning(disable : 4013)
+#endif
+
 void lcb_luv_hexdump(void *data, int size)
 {
     /* dumps size bytes of *data to stdout. Looks like:

--- a/io/util/lcb_luv_yolog.c
+++ b/io/util/lcb_luv_yolog.c
@@ -8,6 +8,10 @@ the Yolog source code for embedding
 /* the following includes needed for APESQ to not try and include
  * its own header (we're inlining it) */
 
+#ifdef _MSC_VER
+#pragma warning(disable : 4267)
+#endif
+
 #if __GNUC__
 #define GENYL__UNUSED __attribute__ ((unused))
 

--- a/lib/couchbase.js
+++ b/lib/couchbase.js
@@ -1,4 +1,4 @@
-var couchnode = require(__dirname + '/../build/Release/couchbase_impl'),
+var couchnode = require('bindings')('couchbase_impl'),
     bucket = require(__dirname + '/bucket'),
     verbose = false; // change to true to spew debug info
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
     "main": "./lib/couchbase",
     "name": "couchbase",
     "dependencies": {
-      "request": "2.11.x"
+      "request": "2.11.x",
+      "bindings": "~1.0.0"
     },
     "repository" : { "type" : "git", "url" : "http://github.com/couchbase/couchnode.git" },
-    "version": "0.0.4"
+    "version": "0.0.4",
+    "gypfile": true
 }

--- a/src/couchbase_impl.h
+++ b/src/couchbase_impl.h
@@ -17,6 +17,13 @@
 #ifndef COUCHBASE_H
 #define COUCHBASE_H 1
 
+#ifdef _MSC_VER
+#pragma warning(disable : 4244)
+#pragma warning(disable : 4267)
+#pragma warning(disable : 4506)
+#pragma warning(disable : 4530)
+#endif
+
 #define BUILDING_NODE_EXTENSION
 #include <node.h>
 

--- a/src/namemap.cc
+++ b/src/namemap.cc
@@ -15,6 +15,7 @@
  *   limitations under the License.
  */
 #include "namemap.h"
+#include "couchbase_impl.h"
 #include <string.h>
 
 using namespace Couchnode;


### PR DESCRIPTION
Firstly, I know that I haven't followed your contributor guidelines and have bypassed Gerrit, I'm not actually expecting you to pull in all of these changes so perhaps this is just a discussion to start with?

I wanted to evaluate Couchbase for a new Node.js project that must run on Windows, so I needed this to compile on Windows. I've started with a _bindings.gyp_ because you're going to need that anyway when node-waf is completely gone (soon). I've also had to make some code tweaks to make it compile on Windows and I've probably made a bit of a mess of it. It now compiles on Linux & Windows (haven't tested OS X). Unfortunately the tests all FAIL on Windows, they hook into libcouchbase properly but get stuck somewhere in there during connection and I'm not sure whether the problem is with couchnode or libcouchbase and I certainly don't have the time to work it all out and get any further for now.

Unfortunately it's a bit difficult to hook in the link to libcouchbase on Windows so I've taken the kludge approach that a few other Node projects with external native dependencies have taken which is to specify exactly where libcouchbase is installed. Ideally libcouchbase would be bundled with couchnode with its own GYP file which would be defined as a dependency in the main bindings.gyp. Alternatively, binaries could be distributed with the package.

I've also pulled in _bindings_ as a dependency as a more reliable way to load the native lib.

Let me know if there's anything I need to explain.

Cheers.
