### PR TITLE
Better JSON format for require

### DIFF
--- a/tests/config.json.sample
+++ b/tests/config.json.sample
@@ -1,6 +1,6 @@
 {
-    username : "Administrator",
-    password : "password",
-    hosts : [ "localhost:8091" ],
-    bucket : "default"
+    "username" : "Administrator",
+    "password" : "password",
+    "hosts" : [ "localhost:8091" ],
+    "bucket" : "default"
 }


### PR DESCRIPTION
I get `SyntaxError: Unexpected token u` with `require` unless the quotes are used.
