### PR TITLE
Allow "include_docs" in db.view

### DIFF
--- a/lib/bucket.js
+++ b/lib/bucket.js
@@ -561,7 +561,7 @@ exports.create = function(connection, config, ready) {
         if (config.debug) console.log("couchbase.bucket.view("+ddoc+","+name+")");
 
         var fields = ["descending", "endkey", "endkey_docid",
-            "full_set", "group", "group_level", "inclusive_end",
+            "full_set", "group", "group_level", "include_docs", "inclusive_end",
             "key", "keys", "limit", "on_error", "reduce", "skip",
             "stale", "startkey", "startkey_docid"];
         var jsonFields = ["endkey", "key", "keys", "startkey"];


### PR DESCRIPTION
For some reason, include_docs wasn't allowed on db.view queries. Simply added it to the allowed query options.