### PR TITLE
Fix improper key encoding in pagination

### DIFF
--- a/lib/viewQuery.js
+++ b/lib/viewQuery.js
@@ -231,7 +231,7 @@ Paginator.prototype.next = function(callback) {
   if (this._nextkey && this._nextkey_docid) {
     var q = extend(
       extend({}, this._qobj.q),
-      {startkey: this._nextkey, startkey_docid: this._nextkey_docid}
+      {startkey: JSON.stringify(this._nextkey), startkey_docid: JSON.stringify(this._nextkey_docid)}
     );
     var p = this;
     var paginate_ = function(err, results) {
@@ -263,7 +263,7 @@ Paginator.prototype.prev = function(callback) {
       p._paginate.call(p, err, results, callback)
     }
     var q = extend(
-      extend({}, this._qobj.q), { startkey: nk[0], startkey_docid: nk[1] }
+      extend({}, this._qobj.q), { startkey: JSON.stringify(nk[0]), startkey_docid: JSON.stringify(nk[1]) }
     );
     q.limit += 1;
     this._qobj._request(q, paginate_)


### PR DESCRIPTION
Keys must be properly JSON encoded (see http://www.couchbase.com/docs/couchbase-manual-2.0/couchbase-views-writing-querying-selection.html).