### PR TITLE
Made multi operations 'options' parameter optional

### DIFF
--- a/lib/couchbase.js
+++ b/lib/couchbase.js
@@ -695,17 +695,19 @@ Connection.prototype.observe = function(key, options, callback) {
 };
 
 Connection.prototype._multiHelper = function(target, argList) {
-  var options = argList[1];
-  if (!options) {
+  var options, cb;
+  if (argList.length === 2) {
     options = { spooled: true };
-  } else if (!('spooled' in options)) {
-    options = { spooled: true };
-    for (var k in argList[1]) {
-      options[k] = argList[1][k];
-    }
+    cb = argList[1];
+  } else {
+    options = argList[1];
+    cb = argList[2];
+  }  
+  if (!('spooled' in options)) {
+    options['spooled'] = true;
   }
   target.call(this._cb, argList[0], options,
-      this._interceptEndure(null, argList[0], options, false, argList[2]));
+      this._interceptEndure(null, argList[0], options, false, cb));
 }
 
 


### PR DESCRIPTION
As stated in the documentation the 'options' parameter of 'Multi' operations should be optional.

This branch makes it so.

Feedback and criticism would be greatly appreciated.

Documentation mentioned:
http://www.couchbase.com/autodocs/couchbase-node-client-0.1.0/index.html