### PR TITLE
Ensure query string gets set when construction new N1qlQuery object

### DIFF
--- a/lib/n1qlquery.js
+++ b/lib/n1qlquery.js
@@ -29,14 +29,16 @@ module.exports = N1qlQuery;
 /**
  * Class for holding a explicitly defined N1QL query string.
  *
+ * @param {string} queryStr The N1QL query string to set when construction the N1QL query object
+ *
  * @constructor
  * @extends N1qlQuery
  *
  * @since 2.0.0
  * @uncommitted
  */
-function N1qlStringQuery() {
-  this.str = '';
+function N1qlStringQuery(queryStr) {
+  this.str = queryStr;
 }
 util.inherits(N1qlStringQuery, N1qlQuery);
 N1qlQuery.Direct = N1qlStringQuery;


### PR DESCRIPTION
The constructor for N1QL was defaulting to an empty string.  Pass in the raw query string and set it to the "str" property on the N1QLQuery object.
