### PR TITLE
Update viewquery.js - small bug when we are not actually sending any group level to couchbase.

### DIFF
--- a/lib/viewquery.js
+++ b/lib/viewquery.js
@@ -238,7 +238,7 @@ DefaultViewQuery.prototype.group = function(group_level) {
     this.options.group_level = group_level;
   } else {
     this.options.group = true;
-    this.options.group_level = 0;
+//    this.options.group_level = 0; {"correction": "This line should be deleted"}
   }
   return this;
 };


### PR DESCRIPTION
This line sends group level key to couchbase which SHOULD NOT when we are grouping on just one field and, group level is not to be mentioned. If sent, the query always returns null.