### PR TITLE
Fix a typo

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -37,7 +37,7 @@ function Cluster(cnstr) {
 Cluster.prototype.openBucket = function(name, password, callback) {
   if (password instanceof Function) {
     callback = arguments[1];
-    password = arguments[9];
+    password = arguments[0];
   }
 
   var bucketDsnObj = connstr.normalize(this.dsnObj);


### PR DESCRIPTION
This method can have 2 or 3 arguments, but there's no 10th argument.