### PR TITLE
Fix bucket manager mock insert view error

### DIFF
--- a/lib/mock/bucket.js
+++ b/lib/mock/bucket.js
@@ -1,5 +1,5 @@
 'use strict';
-
+    
 var events = require('events');
 var util = require('util');
 var ViewQuery = require('../viewquery');

--- a/lib/mock/bucketmgr.js
+++ b/lib/mock/bucketmgr.js
@@ -14,7 +14,7 @@ BucketManager.prototype.getDesignDocuments = function(callback) {
 BucketManager.prototype.insertDesignDocument = function(name, data, callback) {
   var self = this;
   this.getDesignDocument(name, function(err, res) {
-    if (!err) {
+    if (err !== null || undefined) {
       return callback(new Error('design document already exists'), null);
     }
     self.upsertDesignDocument(name, data, callback);


### PR DESCRIPTION
I still have the same error because err is not at false but at null.
This commit fix the issue of 'design document already exists' when it's not.

https://forums.couchbase.com/t/v2-0-0-mock-node-js-implementation-of-insert-ddoc-falsely-reports-ddoc-already-exists/1649