### PR TITLE
Bump Nan to 1.5.1, adds io.js 1.0.1 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "bindings": "~1.2.1",
     "jsonparse": "~0.0.6",
-    "nan": "~1.3.0",
+    "nan": "~1.5.1",
     "request": "~2.45.0"
   },
   "devDependencies": {

--- a/src/constants.cc
+++ b/src/constants.cc
@@ -7,7 +7,7 @@ namespace Couchnode {
  */
 static void define_constant(Handle<Object> target, const char *k, int n)
 {
-    target->Set(NanNew<String>(k), NanNew<Number>(n),
+    target->ForceSet(NanNew<String>(k), NanNew<Number>(n),
                 static_cast<v8::PropertyAttribute>(v8::ReadOnly|v8::DontDelete));
 }
 

--- a/src/couchbase_impl.cc
+++ b/src/couchbase_impl.cc
@@ -168,7 +168,7 @@ void _DispatchArithCallback(lcb_t instance, const void *cookie, lcb_error_t erro
     if (!error) {
         Handle<Object> resObj = NanNew<Object>();
         resObj->Set(NanNew(me->casKey), Cas::CreateCas(resp->v.v0.cas));
-        resObj->Set(NanNew(me->valueKey), NanNew<Integer>(resp->v.v0.value));
+        resObj->Set(NanNew(me->valueKey), NanNew<Number>(resp->v.v0.value));
         resVal = resObj;
     } else {
         resVal = NanNull();


### PR DESCRIPTION
Yo,

this adds io.js 1.0.X support and bumps to Nan 1.5.1 (adds 0.11.XX support in terms of *node-legacy*).

***RFC.***

*jfyi:* The "Orphan:" prefix indicates that there is neither a ticket for this change nor do I want to create an Issue addressing this change.