### PR TITLE
Update bucket options to have `flushEnabled`

### DIFF
--- a/lib/clustermgr.js
+++ b/lib/clustermgr.js
@@ -104,7 +104,8 @@ ClusterManager.prototype.createBucket = function(name, opts, callback) {
     authType: 'sasl',
     bucketType: 'couchbase',
     ramQuotaMB: 100,
-    replicaNumber: 1
+    replicaNumber: 1,
+    flushEnabled: 0
   };
   for (var i in opts) {
     if (opts.hasOwnProperty(i)) {


### PR DESCRIPTION
`flushEnabled` is needed to be enable the flush permission on your bucket