### PR TITLE
Bump Nan to 1.6.2, adds Node 0.12.0 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "bindings": "~1.2.1",
     "jsonparse": "~0.0.6",
-    "nan": "~1.5.1",
+    "nan": "~1.6.2",
     "request": "~2.45.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Yo,

this adds Node 0.12.0 support and bumps to Nan 1.6.2.