### PR TITLE
Fix test credentials

### DIFF
--- a/test/clustermgr.test.js
+++ b/test/clustermgr.test.js
@@ -7,13 +7,13 @@ describe('#cluster management', function() {
   function allTests(H) {
     it('should be able to access a cluster manager', function () {
       var cluster = new H.lib.Cluster(H.connstr);
-      var clusterMgr = cluster.manager('Administrator', 'C0uchbase');
+      var clusterMgr = cluster.manager(H.muser, H.mpass);
       assert(clusterMgr);
     });
 
     it('should be able to list buckets', function () {
       var cluster = new H.lib.Cluster(H.connstr);
-      var clusterMgr = cluster.manager('Administrator', 'C0uchbase');
+      var clusterMgr = cluster.manager(H.muser, H.mpass);
       clusterMgr.listBuckets(function (err, list) {
         assert(!err);
         assert(list);

--- a/test/harness.js
+++ b/test/harness.js
@@ -24,7 +24,7 @@ if (process.env.CNBUCKET !== undefined) {
   config.bucket = process.env.CNBUCKET;
 }
 if (process.env.CNBPASS !== undefined) {
-  config.mpass = process.env.CNBPASS;
+  config.bpass = process.env.CNBPASS;
 }
 if (process.env.CNMUSER !== undefined) {
   config.muser = process.env.CNMUSER;
@@ -87,6 +87,9 @@ function RealHarness() {
   this.connstr = config.connstr;
   this.bucket = config.bucket;
   this.qhosts = config.qhosts;
+  this.bpass = config.bpass;
+  this.muser = config.muser;
+  this.mpass = config.mpass;
 
   this.lib = couchbase;
 


### PR DESCRIPTION
clustermgr tests seem to use hardcoded credentials. this uses the credentials already passed to the harness via environment