### PR TITLE
extract local _httpError function to handle unexpected http response

### DIFF
--- a/lib/bucketmgr.js
+++ b/lib/bucketmgr.js
@@ -16,6 +16,19 @@ function _respRead(callback) {
   };
 }
 
+function _httpError(resp, data, callback) {
+  var reason = 'received HTTP Status-Code ' + resp.statusCode + ' from couchbase';
+  try {
+    var errData = JSON.parse(data);
+    data = errData.reason;
+  } catch (ignoreBadJSON) {
+  }
+  if (data) {
+    reason += ': ' + data;
+  }
+  return callback(new Error(reason), null);
+}
+
 /**
  * @class
  * A class for performing management operations against a bucket. This class
@@ -84,8 +97,7 @@ BucketManager.prototype.getDesignDocuments = function(callback) {
         return callback(err);
       }
       if (resp.statusCode !== 200) {
-        var errData = JSON.parse(data);
-        return callback(new Error(errData.reason), null);
+        return _httpError(resp, data, callback);
       }
       var ddocData = JSON.parse(data);
       var ddocs = {};
@@ -144,8 +156,7 @@ BucketManager.prototype.upsertDesignDocument = function(name, data, callback) {
         return callback(err);
       }
       if (resp.statusCode !== 201) {
-        var errData = JSON.parse(data);
-        return callback(new Error(errData.reason), null);
+        return _httpError(resp, data, callback);
       }
       callback(null, true);
     }));
@@ -182,8 +193,7 @@ BucketManager.prototype.getDesignDocument = function(name, callback) {
       }
       var ddocData = JSON.parse(data);
       if (resp.statusCode !== 200) {
-        var errData = JSON.parse(data);
-        return callback(new Error(errData.reason), null);
+        return _httpError(resp, data, callback);
       }
       callback(null, ddocData);
     }));
@@ -213,8 +223,7 @@ BucketManager.prototype.removeDesignDocument = function(name, callback) {
         return callback(err);
       }
       if (resp.statusCode !== 200) {
-        var errData = JSON.parse(data);
-        return callback(new Error(errData.reason), null);
+        return _httpError(resp, data, callback);
       }
       callback(null, true);
     }));
@@ -246,8 +255,7 @@ BucketManager.prototype.flush = function(callback) {
         return callback(err);
       }
       if (resp.statusCode !== 200) {
-        var errData = JSON.parse(data);
-        return callback(new Error(errData.reason), null);
+        return _httpError(resp, data, callback);
       }
       callback(null, true);
     }));

--- a/lib/clustermgr.js
+++ b/lib/clustermgr.js
@@ -19,6 +19,19 @@ function _respRead(callback) {
   };
 }
 
+function _httpError(resp, data, callback) {
+  var reason = 'received HTTP Status-Code ' + resp.statusCode + ' from couchbase';
+  try {
+    var errData = JSON.parse(data);
+    data = errData.reason;
+  } catch (ignoreBadJSON) {
+  }
+  if (data) {
+    reason += ': ' + data;
+  }
+  return callback(new Error(reason), null);
+}
+
 /**
  * @class
  * Class for performing management operations against a cluster.
@@ -81,8 +94,7 @@ ClusterManager.prototype.listBuckets = function(callback) {
       return callback(err);
     }
     if (resp.statusCode !== 200) {
-      var errData = JSON.parse(data);
-      return callback(new Error(errData.reason), null);
+      return _httpError(resp, data, callback);
     }
     var bucketInfo = JSON.parse(data);
     callback(null, bucketInfo);
@@ -120,12 +132,7 @@ ClusterManager.prototype.createBucket = function(name, opts, callback) {
       return callback(err);
     }
     if (resp.statusCode !== 202) {
-      try {
-        var errData = JSON.parse(data);
-        return callback(new Error(errData.reason), null);
-      } catch(e) {
-        return callback(new Error('operation failed'), null);
-      }
+      return _httpError(resp, data, callback);
     }
     callback(null, true);
   }));
@@ -149,8 +156,7 @@ ClusterManager.prototype.removeBucket = function(name, callback) {
       return callback(err);
     }
     if (resp.statusCode !== 200) {
-      var errData = JSON.parse(data);
-      return callback(new Error(errData.reason), null);
+      return _httpError(resp, data, callback);
     }
     callback(null, true);
   }));


### PR DESCRIPTION
several places deal with unexpected http-response and even use JSON.parse to find a reason, which throws an (uncatched) exception if used i.e. against couchbase-2.2 server. this somewhat unifies http error handling