### PR TITLE
Update clustermgr.js to handle HTTP request error

### DIFF
--- a/lib/clustermgr.js
+++ b/lib/clustermgr.js
@@ -87,6 +87,9 @@ ClusterManager.prototype.listBuckets = function(callback) {
     var bucketInfo = JSON.parse(data);
     callback(null, bucketInfo);
   }));
+  httpReq.on('error', function(e) {
+    return callback(new Error(e.toString()), null);
+  });
   httpReq.end();
 };
 
@@ -129,6 +132,9 @@ ClusterManager.prototype.createBucket = function(name, opts, callback) {
     }
     callback(null, true);
   }));
+  httpReq.on('error', function(e) {
+    return callback(new Error(e.toString()), null);
+  });
   httpReq.write(qs.stringify(myOpts));
   httpReq.end();
 };
@@ -154,6 +160,9 @@ ClusterManager.prototype.removeBucket = function(name, callback) {
     }
     callback(null, true);
   }));
+  httpReq.on('error', function(e) {
+    return callback(new Error(e.toString()), null);
+  });
   httpReq.end();
 };
 


### PR DESCRIPTION
Added handling of HTTP request error for the methods listBuckets, createBucket, removeBucket.
This is to avoid unhandled exceptions when calling any of the methods when there are no connection to the couchbase server.