### PR TITLE
Adding dateToArray to bucket mock.

### DIFF
--- a/lib/mock/bucket.js
+++ b/lib/mock/bucket.js
@@ -932,6 +932,18 @@ MockBucket.prototype._indexView = function(ddoc, name, options, callback) {
   var curdocval = null;
   var curdockey = null;
   var curdocmeta = null;
+
+  function dateToArray (date) {
+    date = date.getUTCDate ? date : new Date(date);
+    return isFinite(date.valueOf()) ?
+      [date.getUTCFullYear(),
+      (date.getUTCMonth() + 1),
+      date.getUTCDate(),
+      date.getUTCHours(),
+      date.getUTCMinutes(),
+      date.getUTCSeconds()] : null;
+  }
+
   function emit(key, val) {
     var row = {
       key: key,


### PR DESCRIPTION
The `dateToArray` function is missing from bucket mocks and will raise errors if used within a view.  I borrowed the dateToArray code from the [couchdb source](https://github.com/couchbase/couchdb/blob/cb21b8ff7c77c7fbf67f23c4f59befd59c794783/src/mapreduce/mapreduce.cc#L52-L67) and added it above the `emit` function declaration.



