### PR TITLE
Update to latest libcouchbase (2.4.8)

### DIFF
--- a/deps/lcb/CMakeLists.txt
+++ b/deps/lcb/CMakeLists.txt
@@ -21,7 +21,7 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.8.9)
 # These variables can be modified as needed
 
 # Couchbase mock path to download
-SET(COUCHBASE_MOCK_VERSION CouchbaseMock-1.0.0-g50cf222.jar)
+SET(COUCHBASE_MOCK_VERSION CouchbaseMock-1.1.0-gda80301.jar)
 # Maven repository where ${COUCHBASE_MOCK_VERSION} is to be found
 SET(COUCHBASE_MOCK_DLSERVER http://packages.couchbase.com/clients/c/mock)
 project(libcouchbase)

--- a/deps/lcb/RELEASE_NOTES.markdown
+++ b/deps/lcb/RELEASE_NOTES.markdown
@@ -1,5 +1,74 @@
 # Release Notes
 
+## 2.4.8 (Mar. 8 2015)
+
+* Retry next nodes on initial bootstrap, even if first node says bucket does
+  not exist (or auth error), as this might be a recently removed node
+  * Priority: Major
+  * Issues: [CCBC-577](http://issues.couchbase.com/browse/CCBC-577)
+
+* The `cbc` and `cbc-pillowfight` binaries on Windows are now distributed
+  in both _release_ and _debug_ variants. Previously they would be clobbered
+  by one or the other depending on the build host. This fixes some issues in
+  performance and dependency resolution when using these libraries.
+  * Priority: Minor
+  * Issues: [CCBC-581](http://issues.couchbase.com/browse/CCBC-581)
+
+* Provide Read-Only config cache mode. In this mode the configuration cache
+  file is read but never updated. Additionally, a missing file in this mode
+  results in a hard error.
+  * Priority: Major
+  * Issues: [CCBC-584](http://issues.couchbase.com/browse/CCBC-584)
+
+* Keep vBucket heuristic guesses for limited periods of time.
+  This will allow previously-learned vBucket master locations to persist
+  over a configuration change, providing these changes were discovered
+  recently. This allows the reduction of not-my-vbucket responses while
+  allowing new configs to overwrite our heuristic info, if the heuristic is
+  too old.
+  * Priority: Major
+
+* Fix potential crashes in get-with-replica (`lcb_rget3`, `lcb_get_replica`)
+  when there are no replicas available, or if there is an error in retrieving
+  from one of the replicas.
+  * Priority: Major
+  * Issues: [CCBC-586](http://issues.couchbase.com/browse/CCBC-586)
+
+* Do not wait between not-my-vbucket retries
+  This behavior restores the pre 2.4.0 behavior of retrying not-my-vbucket
+  responses, with a more intelligent retry/rotation algorithm (see the
+  release note about "vbucket map heuristics"). Previously a wait-time
+  was introduced because of potential busy loops in retrying to the same
+  node. The `LCB_CNTL_RETRY_NMV_IMM` setting can be used to disable this
+  functionality (by disabling it, i.e. setting it to 0). This may also be
+  disabled in the connection string via `retry_nmv_imm=0`.
+  * Priority: Major
+  * Issues: [CCBC-588](http://issues.couchbase.com/browse/CCBC-588)
+
+* Fix compilation error with UV when `EAI_BADHINTS` is not defined in the
+  system. This is primarily an issue with newer UV versions and some versions
+  of Linux
+  * Priority: Major
+  * Issues: [CCBC-590](http://issues.couchbase.com/browse/CCBC-590)
+
+* Allow means to disable C++ behavior on public library structures, allowing
+  them to be initialized via C-style static initializers.
+  This allows the zeroing of structures such as `lcb_get_cmd_t cmd = { 0 }`,
+  which would ordinarily fail under C++ compilation because of that structure
+  having a defined C++ constructor. Applications can take advantage of this
+  feature by defining the `LCB_NO_DEPR_CXX_CTORS` preprocessor macro when
+  compiling.
+  * Priority: Major
+  * Issues: [CCBC-591](http://issues.couchbase.com/browse/CCBC-591)
+
+* Fix some bugs in timing behavior (`lcb_enable_timings`). Timings between
+  1000-2000ms are now reported accurately. Additionally for more common
+  handling, second timing ranges (between 1-9s) are reported in ms range
+  (i.e. timings of 4 seconds are reported as 3000-4000ms ).
+  * Priority: Minor
+  * Issues: [CCBC-582](http://issues.couchbase.com/browse/CCBC-582)
+
+
 ## 2.4.7 (Feb. 17 2015)
 
 * Fix SSL connection failures with `SSL_UNDEFINED_CONST_FUNCTION`.

--- a/deps/lcb/doc/Doxyfile
+++ b/deps/lcb/doc/Doxyfile
@@ -32,7 +32,7 @@ PROJECT_NAME           = "Couchbase C Client"
 # This could be handy for archiving the generated documentation or
 # if some version control system is used.
 
-PROJECT_NUMBER         = 2.4.7
+PROJECT_NUMBER         = 2.4.8
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer
@@ -685,7 +685,6 @@ INPUT += plugins/io/libevent/libevent_io_opts.h
 INPUT += plugins/io/libev/libev_io_opts.h
 INPUT += plugins/io/libuv/libuv_io_opts.h
 INPUT += doc/apiattr.h doc/mainpage.h doc/intro.h doc/environment.h
-INPUT += RELEASE_NOTES.markdown
 INPUT += doc/cbc.markdown doc/cbc-pillowfight.markdown doc/cbcrc.markdown
 
 # This tag can be used to specify the character encoding of the source files

--- a/deps/lcb/include/libcouchbase/_cxxwrap.h
+++ b/deps/lcb/include/libcouchbase/_cxxwrap.h
@@ -22,9 +22,13 @@
  * definitions for backwards compatibility with older code. Users of the library
  * should assume that structures do _not_ behave differently under C++ and must
  * be explicitly initialized with their appropriate members.
+ *
+ * For newer code which wants to use pure "C-Style" initializers, define the
+ * LCB_NO_DEPR_CXX_CTORS macro so that the structures remain to function
+ * as they do in plain C.
  */
 
-#ifdef __cplusplus
+#if defined(__cplusplus) && !defined(LCB_NO_DEPR_CXX_CTORS)
 
 #include <cstdlib>
 #include <cstring>

--- a/deps/lcb/include/libcouchbase/cntl-private.h
+++ b/deps/lcb/include/libcouchbase/cntl-private.h
@@ -320,7 +320,10 @@ typedef enum {
 
 /**
  * @volatile
- * @brief Persist heuristic vbucket information across updates
+ * @brief Persist heuristic vbucket information across updates.
+ *
+ * As of version 2.4.8 this option no longer has any effect, and vBucket
+ * heuristics are always retained for a maximum of 20 seconds.
  * @cntl_arg_both{int*}
  */
 #define LCB_CNTL_VBGUESS_PERSIST 0x32

--- a/deps/lcb/include/libcouchbase/cntl.h
+++ b/deps/lcb/include/libcouchbase/cntl.h
@@ -483,6 +483,17 @@ typedef struct lcb_logprocs_st {
  */
 #define LCB_CNTL_CONFIGCACHE 0x21
 
+/**
+ * @brief File used for read-only configuration cache
+ *
+ * This is identical to the @ref LCB_CNTL_CONFIGCACHE directive, except that
+ * it guarantees that the library will never overwrite or otherwise modify
+ * the path specified.
+ *
+ * @see LCB_CNTL_CONFIGCACHE
+ */
+#define LCB_CNTL_CONFIGCACHE_RO 0x36
+
 typedef enum {
     LCB_SSL_ENABLED = 1 << 0, /**< Use SSL */
     LCB_SSL_NOVERIFY = 1 << 1 /**< Don't verify certificates */
@@ -716,6 +727,20 @@ typedef enum {
 
 /**
  * @volatile
+ * Whether commands are retried immediately upon receipt of not-my-vbucket
+ * replies.
+ *
+ * Since version 2.4.8, packets by default are retried immediately on a
+ * different node if it had previously failed with a not-my-vbucket
+ * response, and is thus not subject to the @ref LCB_CNTL_RETRY_INTERVAL
+ * and @ref LCB_CNTL_RETRY_BACKOFF settings. Disabling this setting will
+ * restore the older behavior. This may be used in case there are problems
+ * with the default heuristic/retry algorithm.
+ */
+#define LCB_CNTL_RETRY_NMV_IMM 0x37
+
+/**
+ * @volatile
  *
  * Set the maximum pool size for pooled http (view request) sockets. This should
  * be set to 1 (the default) unless you plan to execute concurrent view requests.
@@ -748,8 +773,44 @@ typedef enum {
  */
 #define LCB_CNTL_SCHED_IMPLICIT_FLUSH 0x31
 
+/**
+ * @volatile
+ *
+ * Allow the server to return an additional 16 bytes of data for each
+ * mutation operation. This extra information may help with more reliable
+ * durability polling, but will also increase the size of the response packet.
+ *
+ * This should be set on the instance before issuing lcb_connect(). While this
+ * may also be set after lcb_connect() is called, it will currently only take
+ * effect when a server reconnects (which itself may be undefined).
+ *
+ * @cntl_arg_both{int (as boolean)}
+ */
+#define LCB_CNTL_FETCH_SYNCTOKENS 0x34
+
+/**
+ * @volatile
+ *
+ * This setting determines whether the lcb_durability_poll() function will
+ * transparently attempt to use synctoken functionality (rather than checking
+ * the CAS). This option is most useful for older code which does
+ * explicitly use synctokens but would like to use its benefits when
+ * ensuring durability constraints are satisfied.
+ *
+ * This option is enabled by default. Users may wish to disable this if they
+ * are performing durability operations against items stored from different
+ * client instances, as this will make use of a client-global state which is
+ * derived on a per-vBucket basis. This means that the last mutation performed
+ * on a given vBucket for the client will be used, which in some cases may be
+ * older or newer than the mutations passed to the lcb_durability_poll()
+ * function.
+ *
+ * @cntl_arg_both{int (as boolean)}
+ */
+#define LCB_CNTL_DURABILITY_SYNCTOKENS 0x35
+
 /** This is not a command, but rather an indicator of the last item */
-#define LCB_CNTL__MAX                    0x34
+#define LCB_CNTL__MAX                    0x38
 /**@}*/
 
 #ifdef __cplusplus

--- a/deps/lcb/include/libcouchbase/couchbase.h
+++ b/deps/lcb/include/libcouchbase/couchbase.h
@@ -746,6 +746,24 @@ lcb_error_t lcb_destroy_io_ops(lcb_io_opt_t op);
  * @endcode
  */
 
+/**
+ * Structure representing a synchronization token. This token may be used
+ * for durability operations.
+ *
+ * This structure is considered opaque and thus has no alignment requirements.
+ * Its size is fixed at 16 bytes; though.
+ */
+typedef struct {
+    lcb_U64 uuid_;
+    lcb_U64 seqno_;
+    lcb_U16 vbid_;
+} lcb_SYNCTOKEN;
+#define LCB_SYNCTOKEN_ID(p) (p)->uuid_
+#define LCB_SYNCTOKEN_SEQ(p) (p)->seqno_
+#define LCB_SYNCTOKEN_VB(p) (p)->vbid_
+#define LCB_SYNCTOKEN_ISVALID(p) \
+    (p && !((p)->uuid_ == 0 && (p)->seqno_ == 0 && (p)->vbid_ == 0))
+
 /******************************************************************************
  ******************************************************************************
  ******************************************************************************

--- a/deps/lcb/include/libcouchbase/error.h
+++ b/deps/lcb/include/libcouchbase/error.h
@@ -271,8 +271,8 @@ typedef enum {
      the key has been hashed to is not present. This will happen in the result
      of a node failover where no replica exists to replace it. */ \
     X(LCB_NO_MATCHING_SERVER, 0x23, LCB_ERRTYPE_TRANSIENT, \
-      "No node was found for servicing this key. This may be a result of a " \
-      "nonexistent/stale cluster configuration") \
+      "The node the request was mapped to does not exist in the current cluster " \
+      "map. This may be the result of a failover.") \
     \
     /** Received during initial creation (lcb_create()) if an environment variable
      was specified with an incorrect or invalid value.
@@ -429,7 +429,12 @@ typedef enum {
       "The operation structure contains conflicting options") \
     \
     X(LCB_HTTP_ERROR, 0x3B, 0, \
-      "HTTP Operation failed. Inspect status code for details")
+      "HTTP Operation failed. Inspect status code for details") \
+    \
+    X(LCB_DURABILITY_NO_SYNCTOKEN, 0x3C, LCB_ERRTYPE_INPUT, \
+      "The given item does not have a synctoken object associated with it. " \
+      "this is either because fetching synctokens was not enabled, or " \
+      "you are trying to check on something not stored by this instance")
 
 /** Error codes returned by the library. */
 typedef enum {

--- a/deps/lcb/include/libcouchbase/kvbuf.h
+++ b/deps/lcb/include/libcouchbase/kvbuf.h
@@ -33,7 +33,11 @@ extern "C" {
 typedef enum {
     LCB_KV_COPY = 0, /**< The buffer should be copied */
     LCB_KV_CONTIG, /**< The buffer is contiguous and should not be copied */
-    LCB_KV_IOV /**< The buffer is not contiguous and should not be copied */
+    LCB_KV_IOV, /**< The buffer is not contiguous and should not be copied */
+
+    /**For use within the hashkey field, indicates that the _length_
+     * of the hashkey is the vBucket ID, rather than an actual hashkey */
+    LCB_KV_VBID
 } lcb_KVBUFTYPE;
 
 #define LCB_KV_HEADER_AND_KEY LCB_KV_CONTIG

--- a/deps/lcb/include/libcouchbase/plugins/io/libuv/libuv_compat.h
+++ b/deps/lcb/include/libcouchbase/plugins/io/libuv/libuv_compat.h
@@ -80,6 +80,10 @@
 #define EAI_ADDRFAMILY -9
 #endif
 
+#ifndef EAI_BADHINTS
+#define EAI_BADHINTS EAI_FAIL
+#endif
+
 #define OK 0
 
 #if UV_VERSION < 0x000900
@@ -116,6 +120,14 @@
   #define UVC_TIMER_CB(func) \
       void func(uv_timer_t *timer, int status)
 
+  static int uvc_uv2syserr(int status) {
+      #define X(errnum,errname,errdesc) \
+        if (status == UV_##errname) { return errname; }
+      UV_ERRNO_MAP(X);
+      #undef X
+      return 0;
+  }
+
   static int uvc_is_eof(uv_loop_t *loop, int error) {
       error = uv_last_error(loop).code;
       return error == UV_EOF;
@@ -129,14 +141,7 @@
       }
 
       uverr = uv_last_error(loop).code;
-#define X(errnum,errname,errdesc) \
-      if (uverr == UV_##errname) { \
-          return errname; \
-      }
-      UV_ERRNO_MAP(X);
-#undef X
-
-      return 0;
+      return uvc_uv2syserr(uverr);
   }
 
 #else
@@ -162,8 +167,15 @@
   #define UVC_TIMER_CB(func) \
       void func(uv_timer_t *timer)
 
+  static int uv_uv2syserr(int status) {
+      #define X(name, desc) if (status == UV_##name) { return name; }
+      UV_ERRNO_MAP(X)
+      #undef X
+      return 0;
+  }
+
   static int uvc_last_errno(uv_loop_t *loop, int error) {
-      return error;
+      return uv_uv2syserr(error);
   }
 
   static int uvc_is_eof(uv_loop_t *loop, int error) {

--- a/deps/lcb/include/libcouchbase/vbucket.h
+++ b/deps/lcb/include/libcouchbase/vbucket.h
@@ -251,6 +251,15 @@ LIBCOUCHBASE_API
 int
 lcbvb_vbreplica(lcbvb_CONFIG *cfg, int vbid, unsigned ix);
 
+/**
+ * @volatile
+ * This allows to get the given index for a vbucket server. If the index is
+ * 0 then this returns the master index, if the index is greater then it
+ * returns the replica index
+ */
+#define lcbvb_vbserver(cfg, vbid, ix) ( (ix == 0) ? \
+        lcbvb_vbmaster(cfg, vbid) : lcbvb_vbreplica(cfg, vbid, ix-1) )
+
 
 /**
  * @uncommitted

--- a/deps/lcb/plugins/io/libuv/libuv_compat.h
+++ b/deps/lcb/plugins/io/libuv/libuv_compat.h
@@ -80,6 +80,10 @@
 #define EAI_ADDRFAMILY -9
 #endif
 
+#ifndef EAI_BADHINTS
+#define EAI_BADHINTS EAI_FAIL
+#endif
+
 #define OK 0
 
 #if UV_VERSION < 0x000900

--- a/deps/lcb/src/bucketconfig/bc_cccp.c
+++ b/deps/lcb/src/bucketconfig/bc_cccp.c
@@ -132,10 +132,6 @@ static lcb_error_t mcio_error(cccp_provider *cccp, lcb_error_t err)
     if (err != LCB_NOT_SUPPORTED && err != LCB_UNKNOWN_COMMAND) {
         lcb_log(LOGARGS(cccp, ERR), LOGFMT "Got I/O Error=0x%x", LOGID(cccp), err);
     }
-    if (err == LCB_AUTH_ERROR && cccp->base.parent->config == NULL) {
-        lcb_confmon_provider_failed(&cccp->base, err);
-        return err;
-    }
 
     release_socket(cccp, err == LCB_NOT_SUPPORTED);
     return schedule_next_request(cccp, err, 0);

--- a/deps/lcb/src/bucketconfig/bc_http.c
+++ b/deps/lcb/src/bucketconfig/bc_http.c
@@ -69,23 +69,14 @@ io_error(http_provider *http, lcb_error_t origerr)
 {
     lcb_confmon *mon = http->base.parent;
     lcb_settings *settings = mon->settings;
-    int can_retry = 0;
 
     close_current(http);
 
-    if (http->base.parent->config) {
-        can_retry = 1;
-    } else if (origerr != LCB_AUTH_ERROR && origerr != LCB_BUCKET_ENOENT) {
-        can_retry = 1;
-    }
-
-    if (can_retry) {
-        http->creq = lcbio_connect_hl(
-                mon->iot, settings, http->nodes, 0, settings->config_node_timeout,
-                on_connected, http);
-        if (http->creq) {
-            return LCB_SUCCESS;
-        }
+    http->creq = lcbio_connect_hl(
+            mon->iot, settings, http->nodes, 0, settings->config_node_timeout,
+            on_connected, http);
+    if (http->creq) {
+        return LCB_SUCCESS;
     }
 
     lcb_confmon_provider_failed(&http->base, origerr);

--- a/deps/lcb/src/bucketconfig/clconfig.h
+++ b/deps/lcb/src/bucketconfig/clconfig.h
@@ -580,8 +580,12 @@ void lcb_confmon_dump(lcb_confmon *mon, FILE *fp);
 /**
  * Sets the input/output filename for the file provider. This also enables
  * the file provider.
+ * @param p the provider
+ * @param f the filename (if NULL, a temporary filename will be created)
+ * @param ro whether the client will never modify the file
+ * @return zero on success, nonzero on failure.
  */
-int lcb_clconfig_file_set_filename(clconfig_provider *p, const char *f);
+int lcb_clconfig_file_set_filename(clconfig_provider *p, const char *f, int ro);
 
 /**
  * Retrieve the filename for the provider
@@ -589,6 +593,8 @@ int lcb_clconfig_file_set_filename(clconfig_provider *p, const char *f);
  * @return the current filename being used.
  */
 const char * lcb_clconfig_file_get_filename(clconfig_provider *p);
+
+void lcb_clconfig_file_set_readonly(clconfig_provider *p, int val);
 /**@}*/
 
 /**

--- a/deps/lcb/src/callbacks.c
+++ b/deps/lcb/src/callbacks.c
@@ -211,6 +211,10 @@ compat_default_callback(lcb_t instance, int cbtype, const lcb_RESPBASE *r3base)
         target(r3->http._htreq, instance, cookie, err, &r2);
         break;
     }
+    case LCB_CALLBACK_OBSEQNO:
+        /* Don't crash! */
+        break;
+
     default:
         abort();
         break;

--- a/deps/lcb/src/cntl.c
+++ b/deps/lcb/src/cntl.c
@@ -147,6 +147,15 @@ HANDLER(schedflush_handler) {
 HANDLER(vbguess_handler) {
     RETURN_GET_SET(int, LCBT_SETTING(instance, keep_guess_vbs))
 }
+HANDLER(fetch_synctokens_handler) {
+    RETURN_GET_SET(int, LCBT_SETTING(instance, fetch_synctokens))
+}
+HANDLER(dur_synctokens_handler) {
+    RETURN_GET_SET(int, LCBT_SETTING(instance, dur_synctokens))
+}
+HANDLER(nmv_imm_retry_handler) {
+    RETURN_GET_SET(int, LCBT_SETTING(instance, nmv_retry_imm));
+}
 
 HANDLER(get_kvb) {
     struct lcb_cntl_vbinfo_st *vbi = arg;
@@ -297,11 +306,14 @@ HANDLER(init_providers) {
 
 HANDLER(config_cache_handler) {
     clconfig_provider *provider;
-    (void)cmd;
 
     provider = lcb_confmon_get_provider(instance->confmon, LCB_CLCONFIG_FILE);
     if (mode == LCB_CNTL_SET) {
-        if (lcb_clconfig_file_set_filename(provider, (char *)arg) == 0) {
+        int rv;
+        rv = lcb_clconfig_file_set_filename(provider, arg,
+            cmd == LCB_CNTL_CONFIGCACHE_RO);
+
+        if (rv == 0) {
             instance->settings->bc_http_stream_time = LCB_MS2US(10000);
             return LCB_SUCCESS;
         }
@@ -445,7 +457,11 @@ static ctl_handler handlers[] = {
     bucketname_handler, /* LCB_CNTL_BUCKETNAME */
     schedflush_handler, /* LCB_CNTL_SCHED_IMPLICIT_FLUSH */
     vbguess_handler, /* LCB_CNTL_VBGUESS_PERSIST */
-    unsafe_optimize /* LCB_CNTL_UNSAFE_OPTIMIZE */
+    unsafe_optimize, /* LCB_CNTL_UNSAFE_OPTIMIZE */
+    fetch_synctokens_handler, /* LCB_CNTL_FETCH_SYNCTOKENS */
+    dur_synctokens_handler, /* LCB_CNTL_DURABILITY_SYNCTOKENS */
+    config_cache_handler, /* LCB_CNTL_CONFIGCACHE_READONLY */
+    nmv_imm_retry_handler /* LCB_CNTL_RETRY_NMV_IMM */
 };
 
 /* Union used for conversion to/from string functions */
@@ -580,6 +596,7 @@ static cntl_OPCODESTRS stropcode_map[] = {
         {"compression", LCB_CNTL_COMPRESSION_OPTS, convert_compression},
         {"console_log_level", LCB_CNTL_CONLOGGER_LEVEL, convert_u32},
         {"config_cache", LCB_CNTL_CONFIGCACHE, convert_passthru },
+        {"config_cache_ro", LCB_CNTL_CONFIGCACHE_RO, convert_passthru },
         {"detailed_errcodes", LCB_CNTL_DETAILED_ERRCODES, convert_intbool},
         {"retry_policy", LCB_CNTL_RETRYMODE, convert_retrymode},
         {"http_urlmode", LCB_CNTL_HTCONFIG_URLTYPE, convert_int },
@@ -589,6 +606,9 @@ static cntl_OPCODESTRS stropcode_map[] = {
         {"http_poolsize", LCB_CNTL_HTTP_POOLSIZE, convert_SIZE },
         {"vbguess_persist", LCB_CNTL_VBGUESS_PERSIST, convert_intbool },
         {"unsafe_optimize", LCB_CNTL_UNSAFE_OPTIMIZE, convert_intbool },
+        {"fetch_synctokens", LCB_CNTL_FETCH_SYNCTOKENS, convert_intbool },
+        {"dur_synctokens", LCB_CNTL_DURABILITY_SYNCTOKENS, convert_intbool },
+        {"retry_nmv_imm", LCB_CNTL_RETRY_NMV_IMM, convert_intbool },
         {NULL, -1}
 };
 

--- a/deps/lcb/src/config_static.h
+++ b/deps/lcb/src/config_static.h
@@ -110,13 +110,17 @@
 #define SOCKET_ERROR -1
 #endif /* _WIN32 */
 
-#ifndef HAVE_HTONLL
-#ifdef WORDS_BIGENDIAN
-#define ntohll(a) a
-#define htonll(a) a
+
+#if defined(HAVE_HTONLL)
+    #define lcb_htonll htonll
+    #define lcb_ntohll ntohll
+#elif defined(WORDS_BIGENDIAN)
+    #define lcb_ntohll(a) a
+    #define lcb_htonll(a) a
 #else
-#define ntohll(a) lcb_byteswap64(a)
-#define htonll(a) lcb_byteswap64(a)
+    #define lcb_ntohll(a) lcb_byteswap64(a)
+    #define lcb_htonll(a) lcb_byteswap64(a)
+#endif /* HAVE_HTONLL */
 
 #ifdef __cplusplus
 extern "C" {
@@ -125,9 +129,6 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#endif /* WORDS_BIGENDIAN */
-#endif /* HAVE_HTONLL */
-
 
 #ifdef linux
 #undef ntohs

--- a/deps/lcb/src/http/http_io.c
+++ b/deps/lcb/src/http/http_io.c
@@ -238,7 +238,6 @@ on_connected(lcbio_SOCKET *sock, void *arg, lcb_error_t err, lcbio_OSERR syserr)
     lcbio_ctx_rwant(req->ioctx, 1);
     lcbio_ctx_schedule(req->ioctx);
     (void)syserr;
-    (void)settings;
 }
 
 lcb_error_t

--- a/deps/lcb/src/instance.c
+++ b/deps/lcb/src/instance.c
@@ -534,6 +534,7 @@ void lcb_destroy(lcb_t instance)
     }
 
     free(instance->histogram);
+    free(instance->dcpinfo);
     memset(instance, 0xff, sizeof(*instance));
     free(instance);
 #undef DESTROY

--- a/deps/lcb/src/internal.h
+++ b/deps/lcb/src/internal.h
@@ -103,6 +103,7 @@ struct lcb_st {
     lcb_RETRYQ *retryq; /**< Retry queue for failed operations */
     struct lcb_string_st *scratch; /**< Generic buffer space */
     struct lcb_GUESSVB_st *vbguess; /**< Heuristic masters for vbuckets */
+    lcb_SYNCTOKEN *dcpinfo; /**< Mapping of known vbucket to {uuid,seqno} info */
     lcbio_pTIMER dtor_timer; /**< Asynchronous destruction timer */
     int type; /**< Type of connection */
 
@@ -204,7 +205,7 @@ LCB_INTERNAL_API void lcb__timer_destroy_nowarn(lcb_t instance, lcb_timer_t time
     }
 
 void lcb_vbguess_newconfig(lcb_t instance, lcbvb_CONFIG *cfg, struct lcb_GUESSVB_st *guesses);
-int lcb_vbguess_remap(lcbvb_CONFIG *cfg, struct lcb_GUESSVB_st *guesses, int vbid, int bad);
+int lcb_vbguess_remap(lcb_t instance, int vbid, int bad);
 #define lcb_vbguess_destroy(p) free(p)
 
 #ifdef __cplusplus

--- a/deps/lcb/src/legacy.c
+++ b/deps/lcb/src/legacy.c
@@ -18,8 +18,7 @@
 #include "internal.h"
 #include <lcbio/iotable.h>
 
-#if defined(__clang__) || __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
-#pragma GCC diagnostic push
+#if defined(__clang__) || __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 2)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 

--- a/deps/lcb/src/logging.c
+++ b/deps/lcb/src/logging.c
@@ -44,7 +44,7 @@
         #define THREAD_ID_FMT "ld"
     #elif defined(__APPLE__)
         #define GET_THREAD_ID() pthread_mach_thread_np(pthread_self())
-        #define THREAD_ID_FMT "u"
+        #define THREAD_ID_FMT "x"
     #elif defined(__sun) && defined(__SVR4)
         #include <thread.h>
         /* Thread IDs are not global in solaris, so it's nice to print the PID alongside it */

--- a/deps/lcb/src/mc/mcreq.h
+++ b/deps/lcb/src/mc/mcreq.h
@@ -597,18 +597,18 @@ void
 mcreq_wipe_packet(mc_PIPELINE *pipeline, mc_PACKET *packet);
 
 /**
- * Convenience function to extract the proper hashkey from a key_request_t
- * structure
- * @param key the key structure for the item key
- * @param hashkey the key structure for the hashkey
- * @param nheader the size of the header
- * @param[out] target the pointer to receive the target hashkey
- * @param[out] ntarget the pointer to receive the target length
+ * Function to extract mapping information given a key and a hashkey
+ * @param queue The command queue
+ * @param key The structure for the key
+ * @param hashkey The optional hashkey structure
+ * @param nhdr The size of the header (for KV_CONTIG)
+ * @param[out] vbid The vBucket ID
+ * @param[out] srvix The master server's index
  */
 void
-mcreq_extract_hashkey(
-        const lcb_KEYBUF *key, const lcb_KEYBUF *hashkey,
-        lcb_size_t nheader, const void **target, lcb_size_t *ntarget);
+mcreq_map_key(mc_CMDQUEUE *queue,
+    const lcb_KEYBUF *key, const lcb_KEYBUF *hashkey,
+    unsigned nhdr, int *vbid, int *srvix);
 
 
 /**If the packet's vbucket does not have a master node, use the fallback pipeline
@@ -657,7 +657,16 @@ mcreq_get_bodysize(const mc_PACKET *packet);
  * @param pkt the packet
  * @return the total size
  */
-#define mcreq_get_size(pkt) (mcreq_get_bodysize(pkt) + MCREQ_PKT_BASESIZE)
+uint32_t
+mcreq_get_size(const mc_PACKET *packet);
+
+/**
+ * @brief Get the vBucket for the request
+ * @param packet The packet
+ * @return The vBucket ID from the packet.
+ */
+uint16_t
+mcreq_get_vbucket(const mc_PACKET *packet);
 
 /** Initializes a single pipeline object */
 int

--- a/deps/lcb/src/mcserver/mcserver.h
+++ b/deps/lcb/src/mcserver/mcserver.h
@@ -55,7 +55,10 @@ typedef struct mc_SERVER_st {
     int state;
 
     /** Whether compression is supported */
-    int compsupport;
+    short compsupport;
+
+    /** Whether extended 'UUID' and 'seqno' are available for each mutation */
+    short synctokens;
 
     /** IO/Operation timer */
     lcbio_pTIMER io_timer;

--- a/deps/lcb/src/mcserver/negotiate.c
+++ b/deps/lcb/src/mcserver/negotiate.c
@@ -49,6 +49,7 @@ struct mc_SESSINFO {
         char buffer[256];
     } u_auth;
     cbsasl_callback_t sasl_callbacks[4];
+    lcb_U16 features[MEMCACHED_TOTAL_HELLO_FEATURES+1];
 };
 
 /**
@@ -296,9 +297,69 @@ send_sasl_step(mc_pSESSREQ sreq, packet_info *packet)
     return 0;
 }
 
+static int
+send_hello(mc_pSESSREQ sreq)
+{
+    protocol_binary_request_no_extras req;
+    protocol_binary_request_header *hdr = &req.message.header;
+    unsigned ii;
+    static const char client_id[] = LCB_VERSION_STRING;
+    lcb_U16 features[MEMCACHED_TOTAL_HELLO_FEATURES];
+    unsigned nfeatures = 0;
+    lcb_SIZE nclistr;
+
+    features[nfeatures++] = PROTOCOL_BINARY_FEATURE_TLS;
+
+#ifndef LCB_NO_SNAPPY
+    if (sreq->inner->settings->compressopts != LCB_COMPRESS_NONE) {
+        features[nfeatures++] = PROTOCOL_BINARY_FEATURE_DATATYPE;
+    }
+#endif
+
+    if (sreq->inner->settings->fetch_synctokens) {
+        features[nfeatures++] = PROTOCOL_BINARY_FEATURE_MUTATION_SEQNO;
+    }
+
+    nclistr = strlen(client_id);
+    memset(&req, 0, sizeof req);
+    hdr->request.opcode = PROTOCOL_BINARY_CMD_HELLO;
+    hdr->request.magic = PROTOCOL_BINARY_REQ;
+    hdr->request.keylen = htons((lcb_U16)nclistr);
+    hdr->request.bodylen = htonl((lcb_U32)(nclistr+ (sizeof features[0]) * nfeatures));
+    hdr->request.datatype = PROTOCOL_BINARY_RAW_BYTES;
+
+    lcbio_ctx_put(sreq->ctx, req.bytes, sizeof req.bytes);
+    lcbio_ctx_put(sreq->ctx, client_id, strlen(client_id));
+    for (ii = 0; ii < nfeatures; ii++) {
+        lcb_U16 tmp = htons(features[ii]);
+        lcbio_ctx_put(sreq->ctx, &tmp, sizeof tmp);
+    }
+    lcbio_ctx_rwant(sreq->ctx, 24);
+    return 0;
+}
+
+static int
+parse_hello(mc_pSESSREQ sreq, packet_info *packet)
+{
+    /* some caps */
+    const char *cur;
+    const char *payload = PACKET_BODY(packet);
+    const char *limit = payload + PACKET_NBODY(packet);
+    for (cur = payload; cur < limit; cur += 2) {
+        lcb_U16 tmp;
+        memcpy(&tmp, cur, sizeof(tmp));
+        tmp = ntohs(tmp);
+        lcb_log(LOGARGS(sreq, DEBUG), SESSREQ_LOGFMT "Found feature 0x%x (%s)", SESSREQ_LOGID(sreq), tmp, protocol_feature_2_text(tmp));
+        sreq->inner->features[tmp] = 1;
+    }
+    return 0;
+}
+
+
 typedef enum {
     SREQ_S_WAIT,
     SREQ_S_AUTHDONE,
+    SREQ_S_HELLODONE,
     SREQ_S_ERROR
 } sreq_STATE;
 
@@ -360,7 +421,7 @@ handle_read(lcbio_CTX *ioctx, unsigned nb)
             state = SREQ_S_ERROR;
 
         } else {
-            state = SREQ_S_AUTHDONE;
+            state = SREQ_S_HELLODONE;
         }
         lcb_string_release(&str);
         break;
@@ -368,6 +429,7 @@ handle_read(lcbio_CTX *ioctx, unsigned nb)
 
     case PROTOCOL_BINARY_CMD_SASL_AUTH: {
         if (status == PROTOCOL_BINARY_RESPONSE_SUCCESS) {
+            send_hello(sreq);
             state = SREQ_S_AUTHDONE;
             break;
         }
@@ -377,7 +439,7 @@ handle_read(lcbio_CTX *ioctx, unsigned nb)
             state = SREQ_S_ERROR;
             break;
         }
-        if (send_sasl_step(sreq, &info) == 0) {
+        if (send_sasl_step(sreq, &info) == 0 && send_hello(sreq) == 0) {
             state = SREQ_S_WAIT;
         } else {
             state = SREQ_S_ERROR;
@@ -396,6 +458,21 @@ handle_read(lcbio_CTX *ioctx, unsigned nb)
         break;
     }
 
+    case PROTOCOL_BINARY_CMD_HELLO: {
+        state = SREQ_S_HELLODONE;
+        if (status == PROTOCOL_BINARY_RESPONSE_SUCCESS) {
+            parse_hello(sreq, &info);
+        } else if (status == PROTOCOL_BINARY_RESPONSE_UNKNOWN_COMMAND ||
+                status == PROTOCOL_BINARY_RESPONSE_NOT_SUPPORTED) {
+            lcb_log(LOGARGS(sreq, DEBUG), SESSREQ_LOGFMT "Server does not support HELLO", SESSREQ_LOGID(sreq));
+            /* nothing */
+        } else {
+            set_error_ex(sreq, LCB_PROTOCOL_ERROR, "Hello response unexpected");
+            state = SREQ_S_ERROR;
+        }
+        break;
+    }
+
     default: {
         state = SREQ_S_ERROR;
         lcb_log(LOGARGS(sreq, ERROR), SESSREQ_LOGFMT "Received unknown response. OP=0x%x. RC=0x%x", SESSREQ_LOGID(sreq), PACKET_OPCODE(&info), PACKET_STATUS(&info));
@@ -409,7 +486,7 @@ handle_read(lcbio_CTX *ioctx, unsigned nb)
         bail_pending(sreq);
     } else if (state == SREQ_S_ERROR) {
         set_error_ex(sreq, LCB_ERROR, "FIXME: Error code set without description");
-    } else if (state == SREQ_S_AUTHDONE) {
+    } else if (state == SREQ_S_HELLODONE) {
         negotiation_success(sreq);
     } else {
         goto GT_NEXT_PACKET;
@@ -555,5 +632,8 @@ mc_sess_get_saslmech(mc_pSESSINFO info)
 int
 mc_sess_chkfeature(mc_pSESSINFO info, lcb_U16 feature)
 {
-    (void)info; (void)feature; return 0;
+    if (feature > MEMCACHED_TOTAL_HELLO_FEATURES) {
+        return 0;
+    }
+    return info->features[feature];
 }

--- a/deps/lcb/src/nodeinfo.c
+++ b/deps/lcb/src/nodeinfo.c
@@ -68,7 +68,7 @@ return_badhost(lcb_GETNODETYPE type)
 
 LIBCOUCHBASE_API
 const char *
-lcb_get_node(lcb_t instance, lcb_GETNODETYPE type, unsigned index)
+lcb_get_node(lcb_t instance, lcb_GETNODETYPE type, unsigned ix)
 {
     if (type & LCB_NODE_HTCONFIG) {
         if (type & LCB_NODE_CONNECTED) {
@@ -92,17 +92,17 @@ lcb_get_node(lcb_t instance, lcb_GETNODETYPE type, unsigned index)
 
             if (instance->type == LCB_TYPE_BUCKET) {
                 if (vbc) {
-                    index %= LCBVB_NSERVERS(vbc);
-                    hp = lcbvb_get_hostport(vbc, index, LCBVB_SVCTYPE_MGMT, mode);
+                    ix %= LCBVB_NSERVERS(vbc);
+                    hp = lcbvb_get_hostport(vbc, ix, LCBVB_SVCTYPE_MGMT, mode);
 
                 } else if ((type & LCB_NODE_NEVERNULL) == 0) {
                     return NULL;
                 }
             }
             if (hp == NULL && instance->ht_nodes && instance->ht_nodes->nentries) {
-                index %= instance->ht_nodes->nentries;
+                ix %= instance->ht_nodes->nentries;
                 hostlist_ensure_strlist(instance->ht_nodes);
-                hp = instance->ht_nodes->slentries[index];
+                hp = instance->ht_nodes->slentries[ix];
             }
             if (!hp) {
                 if ((hp = return_badhost(type)) == NULL) {
@@ -117,8 +117,8 @@ lcb_get_node(lcb_t instance, lcb_GETNODETYPE type, unsigned index)
         }
     } else if (type & (LCB_NODE_DATA|LCB_NODE_VIEWS)) {
         const mc_SERVER *server;
-        index %= LCBT_NSERVERS(instance);
-        server = LCBT_GET_SERVER(instance, index);
+        ix %= LCBT_NSERVERS(instance);
+        server = LCBT_GET_SERVER(instance, ix);
 
         if ((type & LCB_NODE_CONNECTED) && server->connctx == NULL) {
             return return_badhost(type);

--- a/deps/lcb/src/operations/cbflush.c
+++ b/deps/lcb/src/operations/cbflush.c
@@ -1,0 +1,70 @@
+/*
+ *     Copyright 2010-2012 Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "internal.h"
+#include <http/http.h>
+
+static void
+flush_cb(lcb_t instance, int cbtype, const lcb_RESPBASE *rb)
+{
+    const lcb_RESPHTTP *resp = (const lcb_RESPHTTP *)rb;
+    lcb_RESPCBFLUSH fresp = { 0 };
+    lcb_RESPCALLBACK callback = lcb_find_callback(instance, LCB_CALLBACK_CBFLUSH);
+
+    fresp = *(lcb_RESPBASE *)rb;
+    fresp.rflags |= LCB_RESP_F_FINAL;
+    if (resp->rc == LCB_SUCCESS) {
+        if (resp->htstatus < 200 || resp->htstatus > 299) {
+            fresp.rc = LCB_HTTP_ERROR;
+        }
+    }
+    if (callback) {
+        callback(instance, LCB_CALLBACK_CBFLUSH, (lcb_RESPBASE*)&fresp);
+    }
+    (void)cbtype;
+}
+
+LIBCOUCHBASE_API
+lcb_error_t
+lcb_cbflush3(lcb_t instance, const void *cookie, const lcb_CMDBASE *cmd)
+{
+    lcb_http_request_t htr;
+    lcb_CMDHTTP htcmd = { 0 };
+    lcb_string urlpath;
+    lcb_error_t rc;
+
+    (void)cmd;
+
+    lcb_string_init(&urlpath);
+    lcb_string_appendz(&urlpath, "/pools/default/buckets/");
+    lcb_string_appendz(&urlpath, LCBT_SETTING(instance, bucket));
+    lcb_string_appendz(&urlpath, "/controller/doFlush");
+
+
+    htcmd.type = LCB_HTTP_TYPE_MANAGEMENT;
+    htcmd.method = LCB_HTTP_METHOD_POST;
+    htcmd.reqhandle = &htr;
+    LCB_CMD_SET_KEY(&htcmd, urlpath.base, urlpath.nused);
+
+    rc = lcb_http3(instance, cookie, &htcmd);
+    lcb_string_release(&urlpath);
+
+    if (rc != LCB_SUCCESS) {
+        return rc;
+    }
+    lcb_htreq_setcb(htr, flush_cb);
+    return LCB_SUCCESS;
+}

--- a/deps/lcb/src/operations/counter.c
+++ b/deps/lcb/src/operations/counter.c
@@ -55,8 +55,8 @@ lcb_counter3(
     hdr->request.bodylen =
             htonl(hdr->request.extlen + ntohs(hdr->request.keylen));
 
-    acmd.message.body.delta = ntohll((lcb_uint64_t)cmd->delta);
-    acmd.message.body.initial = ntohll(cmd->initial);
+    acmd.message.body.delta = lcb_htonll((lcb_uint64_t)cmd->delta);
+    acmd.message.body.initial = lcb_htonll(cmd->initial);
     if (!cmd->create) {
         memset(&acmd.message.body.expiration, 0xff,
                sizeof(acmd.message.body.expiration));
@@ -66,7 +66,7 @@ lcb_counter3(
 
     if (cmd->delta < 0) {
         hdr->request.opcode = PROTOCOL_BINARY_CMD_DECREMENT;
-        acmd.message.body.delta = ntohll((lcb_uint64_t)(cmd->delta * -1));
+        acmd.message.body.delta = lcb_htonll((lcb_uint64_t)(cmd->delta * -1));
     } else {
         hdr->request.opcode = PROTOCOL_BINARY_CMD_INCREMENT;
     }

--- a/deps/lcb/src/operations/durability.c
+++ b/deps/lcb/src/operations/durability.c
@@ -201,7 +201,7 @@ static void purge_entries(lcb_DURSET *dset, lcb_error_t err)
 static lcb_error_t poll_once(lcb_DURSET *dset, int initial)
 {
     unsigned ii, n_added = 0;
-    lcb_error_t err;
+    lcb_error_t err = LCB_SUCCESS;
     lcb_MULTICMD_CTX *mctx = NULL;
 
     /**

--- a/deps/lcb/src/operations/observe-seqno.c
+++ b/deps/lcb/src/operations/observe-seqno.c
@@ -1,0 +1,115 @@
+/*
+ *     Copyright 2015 Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+#include "internal.h"
+
+lcb_error_t
+lcb_observe_seqno3(lcb_t instance, const void *cookie, const lcb_CMDOBSEQNO *cmd)
+{
+    mc_PACKET *pkt;
+    mc_SERVER *server;
+    mc_PIPELINE *pl;
+    protocol_binary_request_header hdr;
+    lcb_U64 uuid;
+
+    if (cmd->server_index > LCBT_NSERVERS(instance)) {
+        return LCB_EINVAL;
+    }
+
+    server = LCBT_GET_SERVER(instance, cmd->server_index);
+    pl = &server->pipeline;
+    pkt = mcreq_allocate_packet(pl);
+    mcreq_reserve_header(pl, pkt, MCREQ_PKT_BASESIZE);
+    mcreq_reserve_value2(pl, pkt, 8);
+
+    /* Set the static fields */
+    MCREQ_PKT_RDATA(pkt)->cookie = cookie;
+    MCREQ_PKT_RDATA(pkt)->start = gethrtime();
+    if (cmd->cmdflags & LCB_CMD_F_INTERNAL_CALLBACK) {
+        pkt->flags |= MCREQ_F_PRIVCALLBACK;
+    }
+
+    memset(&hdr, 0, sizeof hdr);
+    hdr.request.opaque = pkt->opaque;
+    hdr.request.magic = PROTOCOL_BINARY_REQ;
+    hdr.request.opcode = PROTOCOL_BINARY_CMD_OBSERVE_SEQNO;
+    hdr.request.datatype = PROTOCOL_BINARY_RAW_BYTES;
+    hdr.request.bodylen = htonl((lcb_U32)8);
+    hdr.request.vbucket = htons(cmd->vbid);
+    memcpy(SPAN_BUFFER(&pkt->kh_span), hdr.bytes, sizeof hdr.bytes);
+
+    uuid = lcb_htonll(cmd->uuid);
+    memcpy(SPAN_BUFFER(&pkt->u_value.single), &uuid, sizeof uuid);
+    mcreq_sched_add(pl, pkt);
+    return LCB_SUCCESS;
+}
+
+const lcb_SYNCTOKEN *
+lcb_resp_get_synctoken(int cbtype, const lcb_RESPBASE *rb)
+{
+    const lcb_SYNCTOKEN *ss = NULL;
+    if (cbtype == LCB_CALLBACK_STORE) {
+        ss = &((const lcb_RESPSTORE*)rb)->synctoken;
+    } else if (cbtype == LCB_CALLBACK_COUNTER) {
+        ss = &((const lcb_RESPCOUNTER*)rb)->synctoken;
+    } else if (cbtype == LCB_CALLBACK_REMOVE) {
+        ss = &((const lcb_RESPREMOVE*)rb)->synctoken;
+    } else {
+        return NULL;
+    }
+    if (ss->uuid_ == 0 && ss->seqno_ == 0) {
+        return NULL;
+    }
+    return ss;
+}
+
+const lcb_SYNCTOKEN *
+lcb_get_synctoken(lcb_t instance, const lcb_KEYBUF *kb, lcb_error_t *errp)
+{
+    int vbix, srvix;
+    lcb_error_t err_s;
+    const lcb_SYNCTOKEN *existing;
+
+    if (!errp) {
+        errp = &err_s;
+    }
+
+    if (!LCBT_VBCONFIG(instance)) {
+        *errp = LCB_CLIENT_ETMPFAIL;
+        return NULL;
+    }
+    if (LCBT_VBCONFIG(instance)->dtype != LCBVB_DIST_VBUCKET) {
+        *errp = LCB_NOT_SUPPORTED;
+        return NULL;
+    }
+    if (!LCBT_SETTING(instance, fetch_synctokens)) {
+        *errp = LCB_NOT_SUPPORTED;
+        return NULL;
+    }
+
+    if (!instance->dcpinfo) {
+        *errp = LCB_DURABILITY_NO_SYNCTOKEN;
+        return NULL;
+    }
+
+    mcreq_map_key(&instance->cmdq, kb, kb, 0, &vbix, &srvix);
+    existing = instance->dcpinfo + vbix;
+    if (existing->uuid_ == 0 && existing->seqno_ == 0) {
+        *errp = LCB_DURABILITY_NO_SYNCTOKEN;
+        return NULL;
+    }
+    *errp = LCB_SUCCESS;
+    return existing;
+}

--- a/deps/lcb/src/retrychk.c
+++ b/deps/lcb/src/retrychk.c
@@ -31,6 +31,7 @@ lcb_should_retry(lcb_settings *settings, mc_PACKET *pkt, lcb_error_t err)
     case PROTOCOL_BINARY_CMD_GET_REPLICA:
     case PROTOCOL_BINARY_CMD_FLUSH:
     case PROTOCOL_BINARY_CMD_OBSERVE:
+    case PROTOCOL_BINARY_CMD_OBSERVE_SEQNO:
     case PROTOCOL_BINARY_CMD_STAT:
     case PROTOCOL_BINARY_CMD_VERBOSITY:
     case PROTOCOL_BINARY_CMD_VERSION:

--- a/deps/lcb/src/retryq.c
+++ b/deps/lcb/src/retryq.c
@@ -329,6 +329,16 @@ lcb_retryq_add(lcb_RETRYQ *rq, mc_EXPACKET *pkt, lcb_error_t err)
     add_op(rq, pkt, err, 0);
 }
 
+void
+lcb_retryq_nmvadd(lcb_RETRYQ *rq, mc_EXPACKET *detchpkt)
+{
+    int flags = 0;
+    if (rq->settings->nmv_retry_imm) {
+        flags = RETRY_SCHED_IMM;
+    }
+    add_op(rq, detchpkt, LCB_NOT_MY_VBUCKET, flags);
+}
+
 static void
 fallback_handler(mc_CMDQUEUE *cq, mc_PACKET *pkt)
 {

--- a/deps/lcb/src/retryq.h
+++ b/deps/lcb/src/retryq.h
@@ -86,6 +86,17 @@ void
 lcb_retryq_add(lcb_RETRYQ *rq, mc_EXPACKET *detchpkt, lcb_error_t err);
 
 /**
+ * Retries the given packet as a result of a NOT_MY_VBUCKET failure. Currently
+ * this is provided to allow for different behavior when handling these types
+ * of responses.
+ *
+ * @param rq The retry queue
+ * @param detchpkt The new packet
+ */
+void
+lcb_retryq_nmvadd(lcb_RETRYQ *rq, mc_EXPACKET *detchpkt);
+
+/**
  * @brief Retry all queued operations
  *
  * This should normally be called when a new server connection is made or when

--- a/deps/lcb/src/settings.c
+++ b/deps/lcb/src/settings.c
@@ -50,6 +50,9 @@ void lcb_default_settings(lcb_settings *settings)
     settings->detailed_neterr = 0;
     settings->refresh_on_hterr = 1;
     settings->sched_implicit_flush = 1;
+    settings->fetch_synctokens = 0;
+    settings->dur_synctokens = 1;
+    settings->nmv_retry_imm = LCB_DEFAULT_NVM_RETRY_IMM;
 }
 
 LCB_INTERNAL_API

--- a/deps/lcb/src/settings.h
+++ b/deps/lcb/src/settings.h
@@ -79,6 +79,8 @@
 #define LCB_DEFAULT_HTCONFIG_URLTYPE LCB_HTCONFIG_URLTYPE_TRYALL
 #define LCB_DEFAULT_COMPRESSOPTS LCB_COMPRESS_NONE
 
+#define LCB_DEFAULT_NVM_RETRY_IMM 1
+
 #include "config.h"
 #include <libcouchbase/couchbase.h>
 
@@ -132,7 +134,10 @@ typedef struct lcb_settings_st {
     unsigned conntype : 1;
     unsigned refresh_on_hterr : 1;
     unsigned sched_implicit_flush : 1;
+    unsigned nmv_retry_imm : 1;
     unsigned keep_guess_vbs : 1;
+    unsigned fetch_synctokens : 1;
+    unsigned dur_synctokens : 1;
     unsigned sslopts : 2;
     unsigned ipv6 : 2;
 

--- a/deps/lcb/src/ssl/ssl_common.c
+++ b/deps/lcb/src/ssl/ssl_common.c
@@ -354,9 +354,9 @@ lcbio_ssl_check(lcbio_SOCKET *sock)
 }
 
 lcb_error_t
-lcbio_ssl_get_error(lcbio_SOCKET *socket)
+lcbio_ssl_get_error(lcbio_SOCKET *sock)
 {
-    lcbio_XSSL *xs = (lcbio_XSSL *)socket->io;
+    lcbio_XSSL *xs = (lcbio_XSSL *)sock->io;
     return xs->errcode;
 }
 

--- a/deps/lcb/src/ssobuf.h
+++ b/deps/lcb/src/ssobuf.h
@@ -1,0 +1,82 @@
+/*
+ *     Copyright 2015 Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+/**
+ * Implementation of dynamic arrays or strings suitable for one or more than
+ * one element. If only a single element is used, extra memory is not allocated
+ * via malloc.
+ */
+
+#include "simplestring.h"
+
+#define LCB_SSOBUF_DECLARE(T) \
+    struct { \
+        unsigned count; \
+        union { \
+            lcb_string alloc; \
+            T single; \
+        } u;\
+    } \
+
+#define LCB_SSOBUF_ALLOC(p, o, T) do { \
+    if ((o)->count == 0) { /* Only allocate a single element */ \
+        *(p) = &(o)->u.single; \
+        (o)->count++; \
+    } else if ((o)->count == 1) { /* Switch over to malloc */ \
+        T ssobuf__tmp = (o)->u.single; \
+        (o)->u.alloc.nused = 0; \
+        (o)->u.alloc.nalloc = 0; \
+        (o)->u.alloc.base = NULL; \
+        if (-1 == lcb_string_reserve(&(o)->u.alloc, sizeof(T) * 2)) { \
+            *(p) = NULL; \
+        } else { \
+            memcpy((o)->u.alloc.base, &ssobuf__tmp, sizeof(T)); \
+            lcb_string_added(&(o)->u.alloc, sizeof(T)); \
+            *(p) = (T*) ((o)->u.alloc.base + (o)->u.alloc.nused); \
+            lcb_string_added(&(o)->u.alloc, sizeof(T)); \
+        } \
+        (o)->count++; \
+    } else if (-1 == lcb_string_reserve(&(o)->u.alloc, sizeof(T))) { \
+        *(p) = NULL; \
+    } else { \
+        *(p) = (T*) ((o)->u.alloc.base + (o)->u.alloc.nused); \
+        lcb_string_added(&(o)->u.alloc, sizeof(T)); \
+        (o)->count++; \
+    } \
+} while (0);
+
+#define LCB_SSOBUF_ALLOC_N(p, o, T, n) do { \
+    if (n == 1) { \
+        LCB_SSOBUF_ALLOC(p, o, T); \
+    } else if (n > 1) { \
+        if (-1 == lcb_string_reserve(&(o)->u.alloc, sizeof(T) * (n) )) { \
+            *(p) = NULL; \
+        } else { \
+            lcb_string_added(&(o)->u.alloc, sizeof(T) * (n) ); \
+            *(p) = (T*)(o)->u.alloc.base; \
+            (o)->count = n; \
+        } \
+    } \
+} while (0);
+
+#define LCB_SSOBUF_CLEAN(o) do { \
+    if ((o)->count > 1) { \
+        lcb_string_release(&(o)->u.alloc); \
+    } \
+} while (0);
+
+#define LCB_SSOBUF_ARRAY(o, t) \
+    ((o)->count > 1 ? ((t*)(o)->u.alloc.base) : &(o)->u.single)

--- a/deps/lcb/src/timings.c
+++ b/deps/lcb/src/timings.c
@@ -108,7 +108,7 @@ lcb_error_t lcb_get_timings(lcb_t instance,
 
     start = 1000;
     for (ii = 0; ii < 100; ++ii) {
-        end = start+100-1;
+        end = (ii + 1) * 100 - 1;
         if (hg->lt10msec[ii]) {
             callback(instance, cookie, LCB_TIMEUNIT_USEC, start, end, hg->lt10msec[ii], max);
         }
@@ -124,17 +124,18 @@ lcb_error_t lcb_get_timings(lcb_t instance,
         start = end + 1;
     }
 
-    start = 1;
-    for (ii = 0; ii < 9; ++ii) {
-        end = ii + 1;
+    start = 1000;
+    for (ii = 1; ii < 9; ++ii) {
+        start = ii * 1000;
+        end = ((ii + 1) * 1000) - 1;
         if (hg->sec[ii]) {
-            callback(instance, cookie, LCB_TIMEUNIT_SEC, start, end, hg->sec[ii], max);
+            callback(instance, cookie, LCB_TIMEUNIT_MSEC, start, end, hg->sec[ii], max);
         }
-        start = end + 1;
     }
 
     if (hg->sec[9]) {
-        callback(instance, cookie, LCB_TIMEUNIT_SEC, 9, 99999, hg->sec[9], max);
+        callback(instance, cookie,
+            LCB_TIMEUNIT_SEC, 9, 9999, hg->sec[9], max);
     }
     return LCB_SUCCESS;
 }
@@ -175,8 +176,9 @@ void lcb_record_metrics(lcb_t instance,
     } else {
         delta /= LCB_S2NS(1);
         if (delta > 9) {
-            delta = 0;
+            delta = 9;
         }
+
         if ((num = ++hg->sec[delta]) > hg->max) {
             hg->max = num;
         }

--- a/deps/lcb/src/utilities.c
+++ b/deps/lcb/src/utilities.c
@@ -22,7 +22,6 @@
  * to call home
  */
 
-#if !defined(HAVE_HTONLL) && !defined(WORDS_BIGENDIAN)
 extern lcb_uint64_t lcb_byteswap64(lcb_uint64_t val)
 {
     lcb_size_t ii;
@@ -34,7 +33,6 @@ extern lcb_uint64_t lcb_byteswap64(lcb_uint64_t val)
     }
     return ret;
 }
-#endif
 
 /**
  * While the C standard library uses 'putenv' for environment variable

--- a/deps/lcb/src/vbucket/rfc1321/md5c-inl.h
+++ b/deps/lcb/src/vbucket/rfc1321/md5c-inl.h
@@ -118,10 +118,10 @@ void MD5Update (context, input, inputLen)
 		unsigned char *input;                                /* input block */
 		unsigned int inputLen;                     /* length of input block */
 {
-	unsigned int i, index, partLen;
+	unsigned int i, ix, partLen;
 
 	/* Compute number of bytes mod 64 */
-	index = (unsigned int)((context->count[0] >> 3) & 0x3F);
+	ix = (unsigned int)((context->count[0] >> 3) & 0x3F);
 
 	/* Update number of bits */
 	if ((context->count[0] += ((UINT4)inputLen << 3))
@@ -129,26 +129,26 @@ void MD5Update (context, input, inputLen)
 		context->count[1]++;
 	context->count[1] += ((UINT4)inputLen >> 29);
 
-	partLen = 64 - index;
+	partLen = 64 - ix;
 
 	/* Transform as many times as possible.
 	*/
 	if (inputLen >= partLen) {
 		MD5_memcpy
-			((POINTER)&context->buffer[index], (POINTER)input, partLen);
+			((POINTER)&context->buffer[ix], (POINTER)input, partLen);
 		MD5Transform (context->state, context->buffer);
 
 		for (i = partLen; i + 63 < inputLen; i += 64)
 			MD5Transform (context->state, &input[i]);
 
-		index = 0;
+		ix = 0;
 	}
 	else
 		i = 0;
 
 	/* Buffer remaining input */
 	MD5_memcpy
-		((POINTER)&context->buffer[index], (POINTER)&input[i],
+		((POINTER)&context->buffer[ix], (POINTER)&input[i],
 		 inputLen-i);
 }
 
@@ -160,15 +160,15 @@ void MD5Final (digest, context)
 		MD5_CTX *context;                                       /* context */
 {
 	unsigned char bits[8];
-	unsigned int index, padLen;
+	unsigned int ix, padLen;
 
 	/* Save number of bits */
 	Encode (bits, context->count, 8);
 
 	/* Pad out to 56 mod 64.
 	*/
-	index = (unsigned int)((context->count[0] >> 3) & 0x3f);
-	padLen = (index < 56) ? (56 - index) : (120 - index);
+	ix = (unsigned int)((context->count[0] >> 3) & 0x3f);
+	padLen = (ix < 56) ? (56 - ix) : (120 - ix);
 	MD5Update (context, PADDING, padLen);
 
 	/* Append length (before padding) */

--- a/deps/lcb/src/vbucket/vbucket.c
+++ b/deps/lcb/src/vbucket/vbucket.c
@@ -693,6 +693,9 @@ svcs_to_json(lcbvb_SERVICES *svc, cJSON *jsvc, int is_ssl)
     EXTRACT_SERVICE("mgmt", mgmt);
     EXTRACT_SERVICE("capi", views);
     EXTRACT_SERVICE("kv", data);
+    EXTRACT_SERVICE("n1ql", n1ql);
+    EXTRACT_SERVICE("indexScan", ixquery);
+    EXTRACT_SERVICE("indexAdmin", ixadmin);
     #undef EXTRACT_SERVICE
 }
 

--- a/deps/lcb/tests/check-all.cc
+++ b/deps/lcb/tests/check-all.cc
@@ -79,7 +79,9 @@ public:
         opt_srcdir("srcdir"), opt_bindir("testdir"), opt_interactive("interactive"),
         opt_verbose("verbose"), opt_cycles("repeat"), opt_libdir("libdir"),
         opt_bins("tests"), opt_realcluster("cluster"),
-        opt_gtest_filter("gtest_filter")
+        opt_gtest_filter("gtest_filter"),
+        opt_gtest_break_on_failure("gtest_break_on_failure"),
+        opt_gtest_catch_exceptions("gtest_catch_exceptions")
     {
         opt_debugger.abbrev('d')
                 .description("Verbatim string to prepend to the binary command line");
@@ -154,6 +156,8 @@ public:
         parser.addOption(opt_bins);
         parser.addOption(opt_realcluster);
         parser.addOption(opt_gtest_filter);
+        parser.addOption(opt_gtest_break_on_failure);
+        parser.addOption(opt_gtest_catch_exceptions);
 
         if (!parser.parse(argc, argv, false)) {
             return false;
@@ -169,6 +173,12 @@ public:
 
         if (!opt_gtest_filter.result().empty()) {
             ss << " " << "--gtest_filter=" << opt_gtest_filter.result();
+        }
+        if (opt_gtest_break_on_failure.passed()) {
+            ss << " " << "--gtest_break_on_failure=1";
+        }
+        if (opt_gtest_catch_exceptions.passed()) {
+            ss << " " << "--gtest_catch_exceptions=1";
         }
 
         binOptions = ss.str();
@@ -254,6 +264,8 @@ private:
     cliopts::StringOption opt_bins;
     cliopts::StringOption opt_realcluster;
     cliopts::StringOption opt_gtest_filter;
+    cliopts::BoolOption opt_gtest_break_on_failure;
+    cliopts::BoolOption opt_gtest_catch_exceptions;
 
     void setJobsFromEnvironment() {
         char *tmp = getenv("MAKEFLAGS");

--- a/deps/lcb/tests/iotests/mock-environment.h
+++ b/deps/lcb/tests/iotests/mock-environment.h
@@ -69,7 +69,8 @@ class MockCommand
     X(PURGE) \
     X(KEYINFO) \
     X(GET_MCPORTS) \
-    X(SET_CCCP)
+    X(SET_CCCP) \
+    X(REGEN_VBCOORDS)
 
 public:
     enum Code {
@@ -247,6 +248,15 @@ public:
      * @param bucket the name of the bucket
      */
     void respawnNode(int index, std::string bucket = "default");
+
+    /**
+     * Regenerate existing UUIDs and sequence numbers on the cluster to
+     * simulate a dcp-style failover. This is a separate command as triggering
+     * this during a "Normal" failover severly slows down the mock.
+     *
+     * @param bucket
+     */
+    void regenVbCoords(std::string bucket = "default");
 
 
     /**

--- a/deps/lcb/tests/iotests/t_configcache.cc
+++ b/deps/lcb/tests/iotests/t_configcache.cc
@@ -99,5 +99,19 @@ TEST_F(ConfigCacheUnitTest, testConfigCache)
     ASSERT_EQ(LCB_SUCCESS, err);
     ASSERT_NE(0, is_loaded);
     lcb_destroy(instance);
+
+    doLcbCreate(&instance, &cropts, MockEnvironment::getInstance());
+    ASSERT_EQ(LCB_SUCCESS, err);
+    err = lcb_cntl(instance, LCB_CNTL_SET, LCB_CNTL_CONFIGCACHE_RO, (void *)filename);
+    ASSERT_EQ(LCB_SUCCESS, err);
+    lcb_destroy(instance);
+
     remove(filename);
+
+    // Try one more time, with a file that does not exist..
+    doLcbCreate(&instance, &cropts, MockEnvironment::getInstance());
+    ASSERT_EQ(LCB_SUCCESS, err);
+    err = lcb_cntl(instance, LCB_CNTL_SET, LCB_CNTL_CONFIGCACHE_RO, (void *)filename);
+    ASSERT_NE(LCB_SUCCESS, err);
+    lcb_destroy(instance);
 }

--- a/deps/lcb/tests/iotests/t_netfail.cc
+++ b/deps/lcb/tests/iotests/t_netfail.cc
@@ -25,6 +25,91 @@
 #define LOGARGS(instance, lvl) \
     instance->settings, "tests-MUT", LCB_LOG_##lvl, __FILE__, __LINE__
 
+#if defined(_WIN32) && !defined(usleep)
+#define usleep(n) Sleep((n) / 1000)
+#endif
+
+namespace {
+class Retryer {
+public:
+    Retryer(time_t maxDuration) : maxDuration(maxDuration) {}
+    void start() {
+        time_t maxTime = time(NULL) + maxDuration;
+        while (!checkCondition()) {
+            trigger();
+            if (checkCondition()) {
+                break;
+            }
+            if (time(NULL) > maxTime) {
+                printf("Time expired and condition still false!\n");
+                break;
+            } else {
+                printf("Sleeping for a bit to allow failover/respawn propagation\n");
+                usleep(100000); // Sleep for 100ms
+            }
+        }
+        EXPECT_TRUE(checkCondition());
+    }
+protected:
+    virtual bool checkCondition() = 0;
+    virtual void trigger() = 0;
+private:
+    time_t maxDuration;
+};
+
+extern "C" {
+static void nopStoreCb(lcb_t, int, const lcb_RESPBASE *) {}
+}
+
+class NumNodeRetryer : public Retryer {
+public:
+    NumNodeRetryer(time_t duration, lcb_t instance, size_t expCount) :
+        Retryer(duration), instance(instance), expCount(expCount) {
+        genDistKeys(LCBT_VBCONFIG(instance), distKeys);
+    }
+
+protected:
+    virtual bool checkCondition() {
+        return lcb_get_num_nodes(instance) == expCount;
+    }
+    virtual void trigger() {
+        lcb_RESPCALLBACK oldCb = lcb_install_callback3(instance, LCB_CALLBACK_STORE, nopStoreCb);
+        lcb_CMDSTORE scmd = { 0 };
+        scmd.operation = LCB_SET;
+        lcb_sched_enter(instance);
+
+        size_t nSubmit = 0;
+        for (size_t ii = 0; ii < distKeys.size(); ii++) {
+            LCB_CMD_SET_KEY(&scmd, distKeys[ii].c_str(), distKeys[ii].size());
+            LCB_CMD_SET_VALUE(&scmd, distKeys[ii].c_str(), distKeys[ii].size());
+            lcb_error_t rc = lcb_store3(instance, NULL, &scmd);
+            if (rc != LCB_SUCCESS) {
+                continue;
+            }
+            nSubmit++;
+        }
+        if (nSubmit) {
+            lcb_sched_leave(instance);
+            lcb_wait(instance);
+        }
+
+        lcb_install_callback3(instance, LCB_CALLBACK_STORE, oldCb);
+    }
+
+private:
+    lcb_t instance;
+    size_t expCount;
+    std::vector<std::string> distKeys;
+};
+}
+
+static void
+syncWithNodeCount(lcb_t instance, size_t expCount)
+{
+    NumNodeRetryer rr(30, instance, expCount);
+    rr.start();
+}
+
 
 extern "C" {
 static void opFromCallback_storeCB(lcb_t, const void *, lcb_storage_t,
@@ -248,7 +333,6 @@ static void ctx_store_callback(lcb_t, const void *cookie, lcb_storage_t,
     StoreContext *ctx = reinterpret_cast<StoreContext *>(
             const_cast<void *>(cookie));
 
-
     std::string s((const char *)resp->v.v0.key, resp->v.v0.nkey);
     ctx->mm[s] = err;
 }
@@ -260,45 +344,39 @@ TEST_F(MockUnitTest, testReconfigurationOnNodeFailover)
     lcb_t instance;
     HandleWrap hw;
     lcb_error_t err;
-
-    const char *argv[] = {
-            "--replicas", "0", "--nodes", "10", NULL
-    };
+    const char *argv[] = { "--replicas", "0", "--nodes", "4", NULL };
 
     MockEnvironment mock_o(argv), *mock = &mock_o;
-
 
     std::vector<std::string> keys;
     std::vector<lcb_store_cmd_t> cmds;
     std::vector<lcb_store_cmd_t *>ppcmds;
 
     mock->createConnection(hw, instance);
-    lcb_uint32_t newtmo = 7500000; // 7.5 sec
-    err = lcb_cntl(instance, LCB_CNTL_SET, LCB_CNTL_OP_TIMEOUT, &newtmo);
-    ASSERT_EQ(LCB_SUCCESS, err);
     instance->settings->vb_noguess = 1;
     lcb_connect(instance);
     lcb_wait(instance);
     ASSERT_EQ(0, lcb_get_num_replicas(instance));
 
+    size_t numNodes = mock->getNumNodes();
 
-    /* mock uses 10 nodes by default */
-    ASSERT_EQ(10, mock->getNumNodes());
     genDistKeys(LCBT_VBCONFIG(instance), keys);
     genStoreCommands(keys, cmds, ppcmds);
     StoreContext ctx;
 
-    lcb_set_store_callback(instance, ctx_store_callback);
-
-    err = lcb_store(instance, &ctx, cmds.size(), &ppcmds[0]);
     mock->failoverNode(0);
-    lcb_wait(instance);
+    syncWithNodeCount(instance, numNodes-1);
 
+    lcb_set_store_callback(instance, ctx_store_callback);
+    err = lcb_store(instance, &ctx, cmds.size(), &ppcmds[0]);
+    ASSERT_EQ(LCB_SUCCESS, err);
+    lcb_wait(instance);
     ctx.check((int)cmds.size());
-    ctx.clear();
-    ASSERT_EQ(9, lcb_get_num_nodes(instance));
 
     mock->respawnNode(0);
+    syncWithNodeCount(instance, numNodes);
+
+    ctx.clear();
     err = lcb_store(instance, &ctx, cmds.size(), &ppcmds[0]);
     lcb_wait(instance);
     ctx.check((int)cmds.size());
@@ -332,7 +410,7 @@ TEST_F(MockUnitTest, testBufferRelocationOnNodeFailover)
     std::string key = "testBufferRelocationOnNodeFailover";
     std::string val = "foo";
 
-    const char *argv[] = { "--replicas", "0", "--nodes", "10", NULL };
+    const char *argv[] = { "--replicas", "0", "--nodes", "4", NULL };
     MockEnvironment mock_o(argv), *mock = &mock_o;
 
     // We need to disable CCCP for this test to receive "Push" style
@@ -347,8 +425,6 @@ TEST_F(MockUnitTest, testBufferRelocationOnNodeFailover)
     lcb_uint32_t tmoval = 15000000;
     lcb_cntl(instance, LCB_CNTL_SET, LCB_CNTL_OP_TIMEOUT, &tmoval);
 
-    /* mock uses 10 nodes by default */
-    ASSERT_EQ(10, mock->getNumNodes());
     lcb_set_store_callback(instance, store_callback);
     lcb_set_get_callback(instance, get_callback);
 
@@ -452,25 +528,6 @@ TEST_F(MockUnitTest, testSaslMechs)
     lcb_destroy(instance);
 }
 
-
-struct mcd_listener {
-    clconfig_listener base;
-    bool called;
-};
-
-extern "C" {
-static void listener_callback(clconfig_listener *lsnbase,
-                              clconfig_event_t event,
-                              clconfig_info *)
-{
-    mcd_listener *lsn = (mcd_listener *)lsnbase;
-    if (event == CLCONFIG_EVENT_GOT_ANY_CONFIG ||
-            event == CLCONFIG_EVENT_GOT_NEW_CONFIG) {
-        lsn->called = true;
-    }
-}
-}
-
 static void
 doManyItems(lcb_t instance, std::vector<std::string> keys)
 {
@@ -486,60 +543,53 @@ doManyItems(lcb_t instance, std::vector<std::string> keys)
     lcb_wait(instance);
 }
 
-TEST_F(MockUnitTest, testMemcachedFailover)
+extern "C" {
+static void mcdFoVerifyCb(lcb_t, int, const lcb_RESPBASE *rb)
+{
+    EXPECT_EQ(LCB_SUCCESS, rb->rc);
+}
+}
+
+TEST_F(MockUnitTest, DISABLED_testMemcachedFailover)
 {
     SKIP_UNLESS_MOCK();
     const char *argv[] = { "--buckets", "cache::memcache", NULL };
     lcb_t instance;
     struct lcb_create_st crParams;
-    mcd_listener lsn;
-    memset(&lsn, 0, sizeof lsn);
-    lsn.base.callback = listener_callback;
+    lcb_RESPCALLBACK oldCb;
 
     MockEnvironment mock_o(argv, "cache"), *mock = &mock_o;
     mock->makeConnectParams(crParams, NULL);
     doLcbCreate(&instance, &crParams, mock);
 
-    // No disconnection interval. It's disconnected immediately.
-    instance->getSettings()->bc_http_stream_time = 0;
-
-    // Attach the listener
-    lcb_confmon_add_listener(instance->confmon, &lsn.base);
-
     // Check internal setting here
     lcb_connect(instance);
     lcb_wait(instance);
-    ASSERT_TRUE(lsn.called);
+    size_t numNodes = mock->getNumNodes();
+
+    oldCb = lcb_install_callback3(instance, LCB_CALLBACK_STORE, mcdFoVerifyCb);
 
     // Get the command list:
     std::vector<std::string> distKeys;
     genDistKeys(LCBT_VBCONFIG(instance), distKeys);
-
     doManyItems(instance, distKeys);
-    http_provider *htprov = (http_provider *)lcb_confmon_get_provider(instance->confmon, LCB_CLCONFIG_HTTP);
-    ASSERT_EQ((lcb_uint32_t)-1, instance->getSettings()->bc_http_stream_time);
-    ASSERT_EQ(0, lcbio_timer_armed(htprov->disconn_timer));
+    // Should succeed implicitly with callback above
 
     // Fail over the first node..
     mock->failoverNode(1, "cache");
-    lsn.called = false;
-
-    for (int ii = 0; ii < 100 && lsn.called == false; ii++) {
-        doManyItems(instance, distKeys);
-    }
-    ASSERT_TRUE(lsn.called);
-    // Call again so the async callback may be invoked.
+    // Set the callback to the previous one. We expect failures here
+    lcb_install_callback3(instance, LCB_CALLBACK_STORE, oldCb);
+    syncWithNodeCount(instance, numNodes-1);
     doManyItems(instance, distKeys);
-    ASSERT_EQ(9, lcb_get_num_nodes(instance));
 
-    doManyItems(instance, distKeys);
     mock->respawnNode(1, "cache");
-    lsn.called = false;
-    for (int ii = 0; ii < 100 && lsn.called == false; ii++) {
-        doManyItems(instance, distKeys);
-    }
-    ASSERT_TRUE(lsn.called);
-    lcb_confmon_remove_listener(instance->confmon, &lsn.base);
+    syncWithNodeCount(instance, numNodes);
+    ASSERT_EQ(numNodes, lcb_get_num_nodes(instance));
+
+    // Restore the verify callback
+    lcb_install_callback3(instance, LCB_CALLBACK_STORE, mcdFoVerifyCb);
+    doManyItems(instance, distKeys);
+
     lcb_destroy(instance);
 }
 

--- a/deps/lcb/tests/iotests/t_obseqno.cc
+++ b/deps/lcb/tests/iotests/t_obseqno.cc
@@ -1,0 +1,157 @@
+#include "iotests.h"
+
+using namespace std;
+class ObseqnoTest : public MockUnitTest {
+};
+
+extern "C" {
+static void storeCb_getstok(lcb_t, int cbtype, const lcb_RESPBASE *rb)
+{
+    EXPECT_EQ(LCB_SUCCESS, rb->rc);
+    const lcb_SYNCTOKEN *tmp = lcb_resp_get_synctoken(cbtype, rb);
+    if (tmp) {
+        *(lcb_SYNCTOKEN *)rb->cookie = *tmp;
+    }
+}
+}
+
+static void
+storeGetStok(lcb_t instance, const string& k, const string& v, lcb_SYNCTOKEN *st)
+{
+    lcb_RESPCALLBACK oldcb = lcb_get_callback3(instance, LCB_CALLBACK_STORE);
+    lcb_install_callback3(instance, LCB_CALLBACK_STORE, storeCb_getstok);
+    lcb_sched_enter(instance);
+    lcb_CMDSTORE cmd = { 0 };
+    LCB_CMD_SET_KEY(&cmd, k.c_str(), k.size());
+    LCB_CMD_SET_VALUE(&cmd, v.c_str(), v.size());
+    cmd.operation = LCB_SET;
+
+    lcb_error_t rc = lcb_store3(instance, st, &cmd);
+    EXPECT_EQ(LCB_SUCCESS, rc);
+    lcb_sched_leave(instance);
+    lcb_wait(instance);
+    lcb_install_callback3(instance, LCB_CALLBACK_STORE, oldcb);
+}
+
+TEST_F(ObseqnoTest, testFetchImplicit) {
+    SKIP_UNLESS_MOCK();
+    HandleWrap hw;
+    lcb_t instance;
+    lcb_error_t rc;
+    createConnection(hw, instance);
+    const char *key = "obseqBasic";
+    const char *value = "value";
+
+    rc = lcb_cntl_string(instance, "dur_synctokens", "true");
+    ASSERT_EQ(LCB_SUCCESS, rc);
+
+    lcb_SYNCTOKEN st_fetched = { 0 };
+    storeGetStok(instance, key, value, &st_fetched);
+    ASSERT_TRUE(st_fetched.uuid_ != 0);
+
+    lcb_KEYBUF kb;
+    LCB_KREQ_SIMPLE(&kb, key, strlen(key));
+
+    const lcb_SYNCTOKEN *ss = lcb_get_synctoken(instance, &kb, &rc);
+    ASSERT_EQ(LCB_SUCCESS, rc);
+    ASSERT_TRUE(ss != NULL);
+    ASSERT_EQ(ss->uuid_, st_fetched.uuid_);
+    ASSERT_EQ(ss->vbid_, st_fetched.vbid_);
+    ASSERT_EQ(ss->seqno_, st_fetched.seqno_);
+}
+
+extern "C" {
+static void
+obseqCallback(lcb_t, int, const lcb_RESPBASE *rb) {
+    lcb_RESPOBSEQNO *pp = (lcb_RESPOBSEQNO *)rb->cookie;
+    *pp = *(const lcb_RESPOBSEQNO *)rb;
+}
+}
+
+static void
+doObserveSeqno(lcb_t instance, const lcb_SYNCTOKEN *ss, int server, lcb_RESPOBSEQNO& resp) {
+    lcb_CMDOBSEQNO cmd = { 0 };
+    cmd.vbid = ss->vbid_;
+    cmd.uuid = ss->uuid_;
+    cmd.server_index = server;
+    lcb_error_t rc;
+
+    lcb_sched_enter(instance);
+    rc = lcb_observe_seqno3(instance, &resp, &cmd);
+    if (rc != LCB_SUCCESS) {
+        resp.rc = rc;
+        resp.rflags |= LCB_RESP_F_CLIENTGEN;
+        return;
+    }
+
+    lcb_RESPCALLBACK oldcb = lcb_get_callback3(instance, LCB_CALLBACK_OBSEQNO);
+    lcb_install_callback3(instance, LCB_CALLBACK_OBSEQNO, obseqCallback);
+    lcb_sched_leave(instance);
+    lcb_wait(instance);
+    lcb_install_callback3(instance, LCB_CALLBACK_OBSEQNO, oldcb);
+}
+
+TEST_F(ObseqnoTest, testObserve) {
+    SKIP_UNLESS_MOCK();
+
+    HandleWrap hw;
+    lcb_t instance;
+    lcb_error_t rc;
+    createConnection(hw, instance);
+    lcbvb_CONFIG *vbc;
+
+    lcb_cntl(instance, LCB_CNTL_GET, LCB_CNTL_VBCONFIG, &vbc);
+
+    lcb_SYNCTOKEN st_fetched = { 0 };
+    const char *key = "testObserve";
+    const char *value = "value";
+
+    // Get the synctoken
+    storeGetStok(instance, key, value, &st_fetched);
+    ASSERT_TRUE(LCB_SYNCTOKEN_ISVALID(&st_fetched));
+
+    for (size_t ii = 0; ii < lcbvb_get_nreplicas(vbc)+1; ii++) {
+        int ix = lcbvb_vbserver(vbc, st_fetched.vbid_, ii);
+        lcb_RESPOBSEQNO resp = { 0 };
+        doObserveSeqno(instance, &st_fetched, ix, resp);
+        ASSERT_EQ(LCB_SUCCESS, resp.rc);
+        ASSERT_EQ(st_fetched.uuid_, resp.cur_uuid);
+        ASSERT_EQ(0, resp.old_uuid);
+//        printf("SEQ_MEM: %lu. SEQ_DISK: %lu\n", resp.mem_seqno, resp.persisted_seqno);
+        ASSERT_GT(resp.mem_seqno, 0);
+        ASSERT_EQ(resp.mem_seqno, resp.persisted_seqno);
+    }
+}
+
+TEST_F(ObseqnoTest, testFailoverFormat) {
+    SKIP_UNLESS_MOCK();
+    HandleWrap hw;
+    lcb_t instance;
+    createConnection(hw, instance);
+    lcbvb_CONFIG *vbc;
+
+    lcb_cntl(instance, LCB_CNTL_GET, LCB_CNTL_VBCONFIG, &vbc);
+    const char *key = "testObserve";
+    const char *value = "value";
+
+    lcb_SYNCTOKEN st_fetched = { 0 };
+    storeGetStok(instance, key, value, &st_fetched);
+
+    MockEnvironment *env = MockEnvironment::getInstance();
+    env->regenVbCoords();
+
+    // Now we should get a different sequence number
+    lcb_RESPOBSEQNO rr;
+    doObserveSeqno(instance, &st_fetched, lcbvb_vbmaster(vbc, st_fetched.vbid_), rr);
+    ASSERT_EQ(LCB_SUCCESS, rr.rc);
+//    printf("Old UUID: %llu\n", rr.old_uuid);
+//    printf("Cur UUID: %llu\n", rr.cur_uuid);
+    ASSERT_GT(rr.old_uuid, 0);
+    ASSERT_EQ(rr.old_uuid, st_fetched.uuid_);
+    ASSERT_NE(rr.old_uuid, rr.cur_uuid);
+    ASSERT_EQ(rr.old_seqno, st_fetched.seqno_);
+
+}
+
+// TODO: We should add more tests here, but in order to do this, we must
+// first validate the mock.

--- a/deps/lcb/tests/iotests/t_smoke.cc
+++ b/deps/lcb/tests/iotests/t_smoke.cc
@@ -470,6 +470,27 @@ TEST_F(SmokeTest, testMemcachedBucket)
     testGet1();
     testGet2();
     testVersion1();
+
+    // A bit out of place, but check that replica commands fail at schedule-time
+    lcb_sched_enter(session);
+    lcb_CMDGETREPLICA cmd = { 0 };
+    LCB_CMD_SET_KEY(&cmd, "key", 3);
+    lcb_error_t rc;
+
+    cmd.strategy = LCB_REPLICA_FIRST;
+    rc = lcb_rget3(session, NULL, &cmd);
+    ASSERT_EQ(LCB_NO_MATCHING_SERVER, rc);
+
+    cmd.strategy = LCB_REPLICA_ALL;
+    rc = lcb_rget3(session, NULL, &cmd);
+    ASSERT_EQ(LCB_NO_MATCHING_SERVER, rc);
+
+    cmd.strategy = LCB_REPLICA_SELECT;
+    cmd.index = 0;
+    rc = lcb_rget3(session, NULL, &cmd);
+    ASSERT_EQ(LCB_NO_MATCHING_SERVER, rc);
+
+
     testMissingBucket();
 }
 

--- a/deps/lcb/tests/start_mock.bat
+++ b/deps/lcb/tests/start_mock.bat
@@ -9,7 +9,7 @@ SET MOCKPATH=%lcbdir%\tests\CouchbaseMock.jar
 java ^
     -client^
     -jar "%MOCKPATH%"^
-    --nodes=10^
+    --nodes=4^
     --host=localhost^
     --port=0^
     %*

--- a/deps/lcb/tests/start_mock.sh
+++ b/deps/lcb/tests/start_mock.sh
@@ -36,7 +36,7 @@ done
 exec java \
        -client \
        -jar "$COUCHBASEMOCK" \
-        --nodes=10 \
+        --nodes=4 \
         --host=localhost \
         --port=0 \
         "$@"

--- a/deps/lcb/tests/vbucket/confdata/bad.json
+++ b/deps/lcb/tests/vbucket/confdata/bad.json
@@ -1,0 +1,101 @@
+{
+  "rev": 5,
+  "name": "bucket-1",
+  "uri": "/pools/default/buckets/bucket-1?bucket_uuid=37e1c1dfc17d74c80c5e3cbbacf57069",
+  "streamingUri": "/pools/default/bucketsStreaming/bucket-1?bucket_uuid=37e1c1dfc17d74c80c5e3cbbacf57069",
+  "nodes": [
+    {
+      "couchApiBase": "http://10.0.0.233:8092/bucket-1%2B37e1c1dfc17d74c80c5e3cbbacf57069",
+      "hostname": "10.0.0.233:8091",
+      "ports": {
+        "proxy": 11211,
+        "direct": 11210
+      }
+    },
+    {
+      "couchApiBase": "http://10.0.0.234:8092/bucket-1%2B37e1c1dfc17d74c80c5e3cbbacf57069",
+      "hostname": "10.0.0.234:8091",
+      "ports": {
+        "proxy": 11211,
+        "direct": 11210
+      }
+    },
+    {
+      "couchApiBase": "http://10.0.0.250:8092/bucket-1%2B37e1c1dfc17d74c80c5e3cbbacf57069",
+      "hostname": "10.0.0.250:8091",
+      "ports": {
+        "proxy": 11211,
+        "direct": 11210
+      }
+    }
+  ],
+  "nodesExt": [
+    {
+      "services": {
+        "mgmt": 8091,
+        "capi": 8092,
+        "meta": 10000,
+        "capiSSL": 18092,
+        "mgmtSSL": 18091,
+        "kv": 11210,
+        "projector": 9999,
+        "kvSSL": 11207,
+        "moxi": 11211
+      },
+      "hostname": "10.0.0.233"
+    },
+    {
+      "services": {
+        "mgmt": 8091,
+        "capi": 8092,
+        "meta": 10000,
+        "capiSSL": 18092,
+        "mgmtSSL": 18091,
+        "kv": 11210,
+        "projector": 9999,
+        "kvSSL": 11207,
+        "moxi": 11211
+      },
+      "hostname": "10.0.0.234"
+    },
+    {
+      "services": {
+        "mgmt": 8091,
+        "capi": 8092,
+        "meta": 10000,
+        "capiSSL": 18092,
+        "mgmtSSL": 18091,
+        "kv": 11210,
+        "projector": 9999,
+        "kvSSL": 11207,
+        "moxi": 11211
+      },
+      "thisNode": true,
+      "hostname": "10.0.0.250"
+    }
+  ],
+  "nodeLocator": "vbucket",
+  "uuid": "37e1c1dfc17d74c80c5e3cbbacf57069",
+  "ddocs": {
+    "uri": "/pools/default/buckets/bucket-1/ddocs"
+  },
+  "vBucketServerMap": {
+    "hashAlgorithm": "CRC",
+    "numReplicas": 1,
+    "serverList": [
+      "10.0.0.233:11210",
+      "10.0.0.234:11210",
+      "10.0.0.250:11210"
+    ],
+    "vBucketMap": []
+  },
+  "bucketCapabilitiesVer": "",
+  "bucketCapabilities": [
+    "cbhello",
+    "touch",
+    "couchapi",
+    "cccp",
+    "xdcrCheckpointing",
+    "nodesExt"
+  ]
+}

--- a/deps/lcb/tests/vbucket/t_config.cc
+++ b/deps/lcb/tests/vbucket/t_config.cc
@@ -198,3 +198,12 @@ TEST_F(ConfigTest, testBadInput)
     lcbvb_destroy(cfg);
 
 }
+
+TEST_F(ConfigTest, testEmptyMap)
+{
+    string emptyTxt = getConfigFile("bad.json");
+    lcbvb_CONFIG *cfg = lcbvb_create();
+    int rc = lcbvb_load_json(cfg, emptyTxt.c_str());
+    ASSERT_EQ(-1, rc);
+    lcbvb_destroy(cfg);
+}

--- a/deps/lcb/tools/CMakeLists.txt
+++ b/deps/lcb/tools/CMakeLists.txt
@@ -13,6 +13,13 @@ ADD_EXECUTABLE(cbc-pillowfight cbc-pillowfight.cc
 TARGET_LINK_LIBRARIES(cbc-pillowfight couchbase)
 
 INSTALL(TARGETS cbc cbc-pillowfight RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# Set this before INSTALL_PDBS in order to set the correct output name
+IF(MSVC)
+    SET_TARGET_PROPERTIES(cbc PROPERTIES DEBUG_OUTPUT_NAME cbc_d)
+    SET_TARGET_PROPERTIES(cbc-pillowfight PROPERTIES DEBUG_OUTPUT_NAME cbc-pillowfight_d)
+ENDIF()
+
 INSTALL_PDBS(cbc)
 INSTALL_PDBS(cbc-pillowfight)
 

--- a/deps/lcb/tools/cbc.cc
+++ b/deps/lcb/tools/cbc.cc
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <fstream>
 #include <libcouchbase/vbucket.h>
+#include <libcouchbase/views.h>
 #include <stddef.h>
 #include "common/options.h"
 #include "common/histogram.h"
@@ -32,13 +33,19 @@ printKeyError(string& key, lcb_error_t err)
 }
 
 static void
-printKeyCasStatus(string& key, const lcb_RESPBASE *resp, const char *message = NULL)
+printKeyCasStatus(string& key, int cbtype, const lcb_RESPBASE *resp,
+    const char *message = NULL)
 {
     fprintf(stderr, "%-20s", key.c_str());
     if (message != NULL) {
         fprintf(stderr, "%s ", message);
     }
     fprintf(stderr, "CAS=0x%"PRIx64"\n", resp->cas);
+    const lcb_SYNCTOKEN *st = lcb_resp_get_synctoken(cbtype, resp);
+    if (st != NULL) {
+        fprintf(stderr, "%-20sSYNCTOKEN=%u,%"PRIu64",%"PRIu64"\n",
+            "", st->vbid_, st->uuid_, st->seqno_);
+    }
 }
 
 extern "C" {
@@ -59,11 +66,11 @@ get_callback(lcb_t, lcb_CALLBACKTYPE, const lcb_RESPGET *resp)
 }
 
 static void
-store_callback(lcb_t, lcb_CALLBACKTYPE, const lcb_RESPSTORE *resp)
+store_callback(lcb_t, lcb_CALLBACKTYPE cbtype, const lcb_RESPSTORE *resp)
 {
     string key = getRespKey((const lcb_RESPBASE*)resp);
     if (resp->rc == LCB_SUCCESS) {
-        printKeyCasStatus(key, (const lcb_RESPBASE *)resp, "Stored.");
+        printKeyCasStatus(key, cbtype, (const lcb_RESPBASE *)resp, "Stored.");
         if (resp->cookie != NULL) {
             map<string,lcb_cas_t>& items = *(map<string,lcb_cas_t>*)resp->cookie;
             items[key] = resp->cas;
@@ -86,14 +93,14 @@ common_callback(lcb_t, int type, const lcb_RESPBASE *resp)
         fprintf(stderr, "%-20s Unlocked\n", key.c_str());
         break;
     case LCB_CALLBACK_REMOVE:
-        printKeyCasStatus(key, resp, "Deleted.");
+        printKeyCasStatus(key, type, resp, "Deleted.");
         break;
     case LCB_CALLBACK_ENDURE: {
         const lcb_RESPENDURE *er = (const lcb_RESPENDURE*)resp;
         char s_tmp[4006];
         sprintf(s_tmp, "Persisted(%u). Replicated(%u).",
             er->npersisted, er->nreplicated);
-        printKeyCasStatus(key, resp, s_tmp);
+        printKeyCasStatus(key, type, resp, s_tmp);
         break;
     }
     default:
@@ -117,6 +124,34 @@ observe_callback(lcb_t, lcb_CALLBACKTYPE, const lcb_RESPOBSERVE *resp)
     } else {
         printKeyError(key, resp->rc);
     }
+}
+
+static void
+obseqno_callback(lcb_t, lcb_CALLBACKTYPE, const lcb_RESPOBSEQNO *resp)
+{
+    int ix = resp->server_index;
+    if (resp->rc != LCB_SUCCESS) {
+        fprintf(stderr,
+            "[%d] ERROR 0x%X (%s)\n", ix, resp->rc, lcb_strerror(NULL, resp->rc));
+        return;
+    }
+    lcb_U64 uuid, seq_disk, seq_mem;
+    if (resp->old_uuid) {
+        seq_disk = seq_mem = resp->old_seqno;
+        uuid = resp->old_uuid;
+    } else {
+        uuid = resp->cur_uuid;
+        seq_disk = resp->persisted_seqno;
+        seq_mem = resp->mem_seqno;
+    }
+    fprintf(stderr, "[%d] UUID=0x%"PRIx64", Cache=%"PRIu64", Disk=%"PRIu64,
+        ix, uuid, seq_mem, seq_disk);
+    if (resp->old_uuid) {
+        fprintf(stderr, "\n");
+        fprintf(stderr, "    FAILOVER. New: UUID=%"PRIx64", Cache=%"PRIu64", Disk=%"PRIu64,
+            resp->cur_uuid, resp->mem_seqno, resp->persisted_seqno);
+    }
+    fprintf(stderr, "\n");
 }
 
 static void
@@ -166,7 +201,7 @@ common_server_callback(lcb_t, int cbtype, const lcb_RESPSERVERBASE *sbase)
 }
 
 static void
-arithmetic_callback(lcb_t, lcb_CALLBACKTYPE, const lcb_RESPCOUNTER *resp)
+arithmetic_callback(lcb_t, lcb_CALLBACKTYPE type, const lcb_RESPCOUNTER *resp)
 {
     string key = getRespKey((const lcb_RESPBASE *)resp);
     if (resp->rc != LCB_SUCCESS) {
@@ -174,25 +209,62 @@ arithmetic_callback(lcb_t, lcb_CALLBACKTYPE, const lcb_RESPCOUNTER *resp)
     } else {
         char buf[4096] = { 0 };
         sprintf(buf, "Current value is %"PRIu64".", resp->value);
-        printKeyCasStatus(key, (const lcb_RESPBASE *)resp, buf);
+        printKeyCasStatus(key, type, (const lcb_RESPBASE *)resp, buf);
     }
 }
+
 static void
-http_chunk_callback(lcb_http_request_t, lcb_t, const void *cookie,
-    lcb_error_t err, const lcb_http_resp_t *resp)
+http_callback(lcb_t, int, const lcb_RESPHTTP *resp)
 {
-    HttpReceiver *ctx = (HttpReceiver *)cookie;
-    ctx->maybeInvokeStatus(err, resp);
-    if (resp->v.v0.nbytes) {
-        ctx->onChunk((const char*)resp->v.v0.bytes, resp->v.v0.nbytes);
+    HttpReceiver *ctx = (HttpReceiver *)resp->cookie;
+    ctx->maybeInvokeStatus(resp);
+    if (resp->nbody) {
+        ctx->onChunk((const char*)resp->body, resp->nbody);
+    }
+    if (resp->rflags & LCB_RESP_F_FINAL) {
+        ctx->onDone();
     }
 }
+
 static void
-http_done_callback(lcb_http_request_t, lcb_t, const void *cookie,
-    lcb_error_t err, const lcb_http_resp_t *resp) {
-    HttpReceiver *ctx = (HttpReceiver *)cookie;
-    ctx->maybeInvokeStatus(err, resp);
-    ctx->onDone();
+view_callback(lcb_t, int, const lcb_RESPVIEWQUERY *resp)
+{
+    if (resp->rflags & LCB_RESP_F_FINAL) {
+        fprintf(stderr, "View query complete!\n");
+    }
+
+    if (resp->rc != LCB_SUCCESS) {
+        fprintf(stderr, "View query failed: 0x%x (%s)\n",
+            resp->rc, lcb_strerror(NULL, resp->rc));
+
+        if (resp->rc == LCB_HTTP_ERROR) {
+            if (resp->htresp != NULL) {
+                HttpReceiver ctx;
+                ctx.maybeInvokeStatus(resp->htresp);
+                if (resp->htresp->nbody) {
+                    fprintf(stderr, "%.*s", (int)resp->htresp->nbody, resp->htresp->body);
+                }
+            }
+        }
+    }
+
+    if (resp->rflags & LCB_RESP_F_FINAL) {
+        if (resp->value) {
+            fprintf(stderr, "Non-row data: %.*s\n",
+                (int)resp->nvalue, resp->value);
+        }
+        return;
+    }
+
+    printf("KEY: %.*s\n", (int)resp->nkey, resp->key);
+    printf("     VALUE: %.*s\n", (int)resp->nvalue, resp->value);
+    printf("     DOCID: %.*s\n", (int)resp->ndocid, resp->docid);
+    if (resp->docresp) {
+        get_callback(NULL, LCB_CALLBACK_GET, resp->docresp);
+    }
+    if (resp->geometry) {
+        printf("     GEO: %.*s\n", (int)resp->ngeometry, resp->geometry);
+    }
 }
 }
 
@@ -534,6 +606,49 @@ ObserveHandler::run()
 }
 
 void
+ObserveSeqnoHandler::run()
+{
+    Handler::run();
+    lcb_install_callback3(instance, LCB_CALLBACK_OBSEQNO, (lcb_RESPCALLBACK)obseqno_callback);
+    const vector<string>& infos = parser.getRestArgs();
+    lcb_CMDOBSEQNO cmd = { 0 };
+    lcbvb_CONFIG *vbc;
+    lcb_error_t rc;
+
+    rc = lcb_cntl(instance, LCB_CNTL_GET, LCB_CNTL_VBCONFIG, &vbc);
+    if (rc != LCB_SUCCESS) {
+        throw rc;
+    }
+
+    lcb_sched_enter(instance);
+
+    for (size_t ii = 0; ii < infos.size(); ++ii) {
+        const string& cur = infos[ii];
+        unsigned vbid;
+        unsigned long long uuid;
+        int rv = sscanf(cur.c_str(), "%u,%llu", &vbid, &uuid);
+        if (rv != 2) {
+            throw "Must pass sequences of base10 vbid and base16 uuids";
+        }
+        cmd.uuid = uuid;
+        cmd.vbid = vbid;
+        for (size_t jj = 0; jj < lcbvb_get_nreplicas(vbc) + 1; ++jj) {
+            int ix = lcbvb_vbserver(vbc, vbid, jj);
+            if (ix < 0) {
+                fprintf(stderr, "Server %d unavailable (skipping)\n", ix);
+            }
+            cmd.server_index = ix;
+            rc = lcb_observe_seqno3(instance, NULL, &cmd);
+            if (rc != LCB_SUCCESS) {
+                throw rc;
+            }
+        }
+    }
+    lcb_sched_leave(instance);
+    lcb_wait(instance);
+}
+
+void
 UnlockHandler::run()
 {
     Handler::run();
@@ -733,28 +848,61 @@ ArithmeticHandler::run()
 }
 
 void
-HttpReceiver::install(lcb_t instance)
+ViewsHandler::run()
 {
-    lcb_set_http_data_callback(instance, http_chunk_callback);
-    lcb_set_http_complete_callback(instance, http_done_callback);
+    Handler::run();
+
+    const string& s = getRequiredArg();
+    size_t pos = s.find('/');
+    if (pos == string::npos) {
+        throw "View must be in the format of design/view";
+    }
+
+    string ddoc = s.substr(0, pos);
+    string view = s.substr(pos+1);
+    string opts = o_params.result();
+
+    lcb_CMDVIEWQUERY cmd = { 0 };
+    lcb_view_query_initcmd(&cmd,
+        ddoc.c_str(), view.c_str(), opts.c_str(), view_callback);
+    if (o_spatial) {
+        cmd.cmdflags |= LCB_CMDVIEWQUERY_F_SPATIAL;
+    }
+    if (o_incdocs) {
+        cmd.cmdflags |= LCB_CMDVIEWQUERY_F_INCLUDE_DOCS;
+    }
+
+    lcb_error_t rc;
+    rc = lcb_view_query(instance, NULL, &cmd);
+    if (rc != LCB_SUCCESS) {
+        throw rc;
+    }
+    lcb_wait(instance);
 }
 
 void
-HttpReceiver::maybeInvokeStatus(lcb_error_t err, const lcb_http_resp_t *resp)
+HttpReceiver::install(lcb_t instance)
+{
+    lcb_install_callback3(instance, LCB_CALLBACK_HTTP,
+        (lcb_RESPCALLBACK)http_callback);
+}
+
+void
+HttpReceiver::maybeInvokeStatus(const lcb_RESPHTTP *resp)
 {
     if (statusInvoked) {
         return;
     }
 
     statusInvoked = true;
-    if (resp->v.v0.headers) {
-        for (const char * const *cur = resp->v.v0.headers; *cur; cur += 2) {
+    if (resp->headers) {
+        for (const char * const *cur = resp->headers; *cur; cur += 2) {
             string key = cur[0];
             string value = cur[1];
             headers[key] = value;
         }
     }
-    handleStatus(err, resp->v.v0.status);
+    handleStatus(resp->rc, resp->htstatus);
 }
 
 void
@@ -1015,6 +1163,7 @@ static const char* optionsOrder[] = {
         "cat",
         "create",
         "observe",
+        "observe-seqno",
         "incr",
         "decr",
         "mcflush",
@@ -1101,6 +1250,7 @@ setupHandlers()
     handlers_s["connstr"] = new ConnstrHandler();
     handlers_s["write-config"] = new WriteConfigHandler();
     handlers_s["strerror"] = new StrErrorHandler();
+    handlers_s["observe-seqno"] = new ObserveSeqnoHandler();
 
 
 


### PR DESCRIPTION
This is an upgrade to libcouchbase 2.4.8.
All tests are still ok.

This is helpful to us, because of the [compatibility issue with node 0.12 and Linux](https://forums.couchbase.com/t/build-fail-couchnode-2-0-6-and-node-0-12/3291/2).

ps. it just a copy of the 2.4.8 libcouchbase files, no build, so maybe it's missing something (my first attempt in this era)