### PR TITLE
Bucket multi helpers

### DIFF
--- a/lib/bucket.js
+++ b/lib/bucket.js
@@ -873,49 +873,6 @@ Bucket.prototype.get = function(key, options, callback) {
 };
 
 /**
- * Retrieves a list of keys
- *
- * @param {Array.<Buffer|string>} keys
- * The target document keys.
- * @param {Bucket.MultiGetCallback} callback
- *
- * @see Bucket#get
- *
- * @since 2.0.0
- * @committed
- */
-Bucket.prototype.getMulti = function(keys, callback) {
-  if (!Array.isArray(keys) || keys.length === 0) {
-    throw new TypeError('First argument needs to be an array of length > 0.');
-  }
-  if (typeof callback !== 'function') {
-    throw new TypeError('Second argument needs to be a callback.');
-  }
-
-  var self = this;
-  var outMap = {};
-  var resCount = 0;
-  var errCount = 0;
-  function getSingle(key) {
-    self.get(key, function(err, res) {
-      resCount++;
-      if (err) {
-        errCount++;
-        outMap[key] = { error: err };
-      } else {
-        outMap[key] = res;
-      }
-      if (resCount === keys.length) {
-        return callback(errCount, outMap);
-      }
-    });
-  }
-  for (var i = 0; i < keys.length; ++i) {
-    getSingle(keys[i]);
-  }
-};
-
-/**
  * Retrieves a document and updates the expiry of the item at the same time.
  *
  * @param {string|Buffer} key
@@ -969,7 +926,7 @@ Bucket.prototype.getAndTouch = function(key, expiry, options, callback) {
  *
  * Once locked, a document can be unlocked either by explicitly calling
  * {@link Bucket#unlock} or by performing a storage operation
- * (e.g. {@link Bucket#set}, {@link Bucket#replace}, {@link Bucket::append})
+ * (e.g. {@link Bucket#upsert}, {@link Bucket#replace}, {@link Bucket::append})
  * with the current CAS value.  Note that any other lock operations on this
  * key will fail while a document is locked.
  *
@@ -1102,7 +1059,7 @@ Bucket.prototype.touch = function(key, expiry, options, callback) {
 
 /**
  * Unlock a previously locked document on the server.  See the
- * {@link Bucket#lock} method for more details on locking.
+ * {@link Bucket#getAndLock} method for more details on locking.
  *
  * @param {string|Buffer} key
  * The target document key.
@@ -1279,8 +1236,8 @@ Bucket.prototype.insert = function(key, value, options, callback) {
 };
 
 /**
- * Identical to {@link Bucket#set}, but will only succeed if the document
- * exists already (i.e. the inverse of {@link Bucket#add}).
+ * Identical to {@link Bucket#upsert}, but will only succeed if the document
+ * exists already (i.e. the inverse of {@link Bucket#insert}).
  *
  * @param {string|Buffer} key
  * The target document key.
@@ -1308,7 +1265,7 @@ Bucket.prototype.replace = function(key, value, options, callback) {
 };
 
 /**
- * Similar to {@link Bucket#set}, but instead of setting a new key,
+ * Similar to {@link Bucket#upsert}, but instead of setting a new key,
  * it appends data to the existing key. Note that this function only makes
  * sense when the stored data is a string; 'appending' to a JSON document may
  * result in parse errors when the document is later retrieved.
@@ -1424,6 +1381,309 @@ Bucket.prototype.counter = function(key, delta, options, callback) {
     [key, options.hashkey, options.expiry, delta, options.initial,
       this._interceptEndure(key, options, 0, callback)]);
 };
+
+/**
+ * Fire a list of operations.
+ *
+ * @param {string} operation
+ * The type of operation: get, upsert, counter, etc
+ * @param {Array.<Buffer|string> | Object.<string,Object>} kv
+ * The target document keys like [key1,key2], or keyvalue-operation like {key: {value: document, option: 0}} depending on the operation.
+ * @param {Object} [options]
+ * Options for every operation, overridden by the item options if any
+ * @param {Bucket.OpCallback} callback
+ * @param {string} extraAttr
+ * The extra attribute available on the kv object for each key (value for upsert, delta for counter, etc).
+ *
+ * @example
+ * bucket._multi('get', [key1, key2, key3], function(err, v) {})
+ * @example
+ * bucket._multi('upsert', {key1: {value: document, cas: 0}, key2: {value: document}}, {expiry: 10}, function(err, v) {}, 'value')
+ *
+ * @returns
+ * {key1: {value: document, cas: 0}, key2: {error: err}}
+ *
+ * @since 2.0.7
+ * @committed
+ */
+
+Bucket.prototype._multi = function(operation, kv, options, callback, extraAttr) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
+
+  if (!Array.isArray(kv) && typeof kv !== 'object'
+    || Array.isArray(kv) && kv.length === 0
+    || typeof kv === 'object' && kv === null)
+  {
+    throw new TypeError('First argument needs to be an object or array of length > 0.');
+  }
+  if (typeof callback !== 'function') {
+    throw new TypeError('Last argument needs to be a callback.');
+  }
+
+  var self = this;
+  var outMap = {};
+  var resCount = 0;
+  var errCount = 0;
+  var count = kv.length ? kv.length : Object.keys(kv).length;
+  function single (key, keyOptions, value) {
+    var opts = util._extend({}, options);
+    function cb(err, res) {
+      resCount++;
+      if (err) {
+        errCount++;
+        outMap[key] = { error: err };
+      } else {
+        outMap[key] = res;
+      }
+      if (resCount === count) {
+        return callback(errCount, outMap);
+      }
+    };
+
+    if (keyOptions)
+      util._extend(opts, keyOptions);
+
+    if(!value)
+      self[operation](key, opts, cb);
+    else
+      self[operation](key, value, opts, cb);
+  };
+
+  if (Array.isArray(kv)) {
+    // keys -> [key1, key2, key3]
+    for (var index in kv) {
+      single(kv[index]);
+    }
+  } else {
+    // kv -> {key1: {delta: -1, initial: 5}}
+    for (var key in kv) {
+      single(key, kv[key], !extraAttr ? null : (kv[key][extraAttr] || options[extraAttr]));
+    }
+  }
+},
+
+/**
+ * Retrieves a list of keys.
+ *
+ * @param {Array.<Buffer|string>} keys
+ * The target document keys.
+ * @param {Object} [options]
+ * @param {Bucket.OpCallback} callback
+ *
+ * @see Bucket#get
+ *
+ * @since 2.0.0
+ * @committed
+ */
+Bucket.prototype.getMulti = function(keys, options, callback) {
+  this._multi('get', keys, options, callback);
+};
+
+/**
+ * Stores a list of documents to the bucket.
+ *
+ * @param {Array.<Buffer|string>} kv
+ *  @param {Mixed} kv.value
+ *  @param {CAS} [kv.cas]
+ * @param {Object} [options]
+ * @param {Bucket.OpCallback} callback
+ *
+ * @see Bucket#upsert
+ *
+ * @since 2.0.7
+ * @committed
+ */
+Bucket.prototype.upsertMulti = function(kv, options, callback) {
+ this._multi('upsert', kv, options, callback, 'value');
+};
+
+/**
+* Identical to {@link Bucket#upsertMulti} but will fail if the document already
+* exists.
+*
+* @param {Object.<string,Object>} kv
+*  @param {Mixed} kv.value
+* @param {Object} [options]
+* @param {Bucket.OpCallback} callback
+*
+* @see Bucket#insert
+*
+* @since 2.0.7
+* @committed
+*/
+Bucket.prototype.insertMulti = function(kv, options, callback) {
+ this._multi('insert', kv, options, callback, 'value');
+};
+
+/**
+* Identical to {@link Bucket#upsertMulti}, but will only succeed if the document
+* exists already (i.e. the inverse of {@link Bucket#insert}).
+*
+* @param {Object.<string,Object>} kv
+*  @param {Mixed} kv.value
+*  @param {CAS} [kv.cas]
+* @param {Object} [options]
+* @param {Bucket.OpCallback} callback
+*
+* @see Bucket#replace
+*
+* @since 2.0.7
+* @committed
+*/
+Bucket.prototype.replaceMulti = function(kv, options, callback) {
+ this._multi('replace', kv, options, callback, 'value');
+};
+
+/**
+* Similar to {@link Bucket#upsertMulti}, but instead of setting new keys,
+* it appends data to the existing keys. Note that this function only makes
+* sense when the stored data is a string; 'appending' to a JSON document may
+* result in parse errors when the document is later retrieved.
+*
+* @param {Object.<string,Object>} kv
+*  @param {Mixed} kv.value
+*  @param {!*} kv.fragment
+* @param {Object} [options]
+* @param {Bucket.OpCallback} callback
+*
+* @see Bucket#append
+*
+* @since 2.0.7
+* @committed
+*/
+Bucket.prototype.appendMulti = function(kv, options, callback) {
+ this._multi('append', kv, options, callback, 'fragment');
+};
+
+/**
+* Like {@linkcode Bucket#appendMulti}, but prepends data to the existing value.
+*
+* @param {Object.<string,Object>} kv
+*  @param {Mixed} kv.value
+*  @param {!*} kv.fragment
+* @param {Object} [options]
+* @param {Bucket.OpCallback} callback
+*
+* @see Bucket#prepend
+*
+* @since 2.0.7
+* @committed
+*/
+Bucket.prototype.prependMulti = function(kv, options, callback) {
+ this._multi('prepend', kv, options, callback, 'fragment');
+};
+
+/**
+ * Increments or decrements a key's numeric value.
+ *
+ * @param {Object.<string,Object>} kv
+ *  @param {Mixed} kv.value
+ *  @param {number} kv.delta
+ * @param {Object} [options]
+ * @param {Bucket.OpCallback} callback
+ *
+ * @see Bucket#getAndLock
+ *
+ * @since 2.0.7
+ * @committed
+ */
+Bucket.prototype.counterMulti = function(kv, options, callback) {
+  this._multi('counter', kv, options, callback, 'delta');
+};
+
+/**
+* Lock the document on the server and retrieve it. When an document is locked,
+* its CAS changes and subsequent operations on the document (without providing
+* the current CAS) will fail until the lock is no longer held.
+*
+* @param {Array.<Buffer|string>} keys
+* The target document keys.
+* @param {Object} [options]
+* @param {Bucket.OpCallback} callback
+*
+* @see Bucket#getAndLock
+*
+* @since 2.0.7
+* @committed
+*/
+Bucket.prototype.getAndLockMulti = function(keys, options, callback) {
+ this._multi('getAndLock', keys, options, callback);
+};
+
+/**
+* Unlock a previously locked document on the server.  See the
+* {@link Bucket#getAndLockMulti} method for more details on locking.
+*
+* @param {Object.<string,Object>} kv
+*  @param {Mixed} kv.value
+*  @param {CAS} kv.cas
+* @param {Object} [options]
+* @param {Bucket.OpCallback} callback
+*
+* @see Bucket#getAndLock
+*
+* @since 2.0.7
+* @committed
+*/
+Bucket.prototype.unlockMulti = function(kv, options, callback) {
+ this._multi('unlock', kv, options, callback, 'cas');
+};
+
+/**
+ * Update the documents expiration time.
+ *
+ * @param {Array.<Buffer|string>} kv
+ *  @param {Mixed} kv.value
+ *  @param {number} kv.expiry
+ * @param {Object} [options]
+ * @param {Bucket.OpCallback} callback
+ *
+ * @see Bucket#getMulti
+ *
+ * @since 2.0.7
+ * @committed
+ */
+Bucket.prototype.touchMulti = function(kv, options, callback) {
+  this._multi('touch', kv, options, callback, 'expiry');
+};
+
+/**
+ * Retrieves a list of documents and updates the expiry of its items at the same time.
+ *
+ * @param {Array.<Buffer|string>} kv
+ *  @param {Mixed} kv.value
+ *  @param {number} kv.expiry
+ * @param {Object} [options]
+ * @param {Bucket.OpCallback} callback
+ *
+ * @see Bucket#getMulti
+ *
+ * @since 2.0.7
+ * @committed
+ */
+Bucket.prototype.getAndTouchMulti = function(kv, options, callback) {
+  this._multi('getAndTouch', kv, options, callback, 'expiry');
+};
+
+ /**
+  * Deletes a document on the server.
+  *
+  * @param {Array.<Buffer|string>} keys
+  * The target document keys.
+  * @param {Object} [options]
+  * @param {Bucket.OpCallback} callback
+  *
+  * @see Bucket#remove
+  *
+  * @since 2.0.7
+  * @committed
+  */
+ Bucket.prototype.removeMulti = function(keys, options, callback) {
+   this._multi('remove', keys, options, callback);
+ };
 
 /**
  * Gets or sets the operation timeout in milliseconds. The operation timeout

--- a/lib/mock/bucket.js
+++ b/lib/mock/bucket.js
@@ -329,37 +329,6 @@ MockBucket.prototype.get = function(key, options, callback) {
   }, callback);
 };
 
-MockBucket.prototype.getMulti = function(keys, callback) {
-  if (!Array.isArray(keys) || keys.length === 0) {
-    throw new TypeError('First argument needs to be an array of non-zero length.');
-  }
-  if (typeof callback !== 'function') {
-    throw new TypeError('Second argument needs to be a callback.');
-  }
-
-  var self = this;
-  var outMap = {};
-  var resCount = 0;
-  var errCount = 0;
-  function getSingle(key) {
-    self.get(key, function(err, res) {
-      resCount++;
-      if (err) {
-        errCount++;
-        outMap[key] = { error: err };
-      } else {
-        outMap[key] = res;
-      }
-      if (resCount === keys.length) {
-        return callback(errCount, outMap);
-      }
-    });
-  }
-  for (var i = 0; i < keys.length; ++i) {
-    getSingle(keys[i]);
-  }
-};
-
 MockBucket.prototype.getAndTouch = function(key, expiry, options, callback) {
   if (options instanceof Function) {
     callback = arguments[2];
@@ -866,6 +835,112 @@ MockBucket.prototype.query = function(query, params, callback) {
         'First argument needs to be a ViewQuery, SpatialQuery or N1qlQuery.');
   }
 };
+
+MockBucket.prototype._multi = function(operation, kv, options, callback, extraAttr) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
+
+  if (!Array.isArray(kv) && typeof kv !== 'object'
+    || Array.isArray(kv) && kv.length === 0
+    || typeof kv === 'object' && kv === null)
+  {
+    throw new TypeError('First argument needs to be an object or array of length > 0.');
+  }
+  if (typeof callback !== 'function') {
+    throw new TypeError('Last argument needs to be a callback.');
+  }
+
+  var self = this;
+  var outMap = {};
+  var resCount = 0;
+  var errCount = 0;
+  var count = kv.length ? kv.length : Object.keys(kv).length;
+  function single (key, keyOptions, value) {
+    var opts = util._extend({}, options);
+    function cb(err, res) {
+      resCount++;
+      if (err) {
+        errCount++;
+        outMap[key] = { error: err };
+      } else {
+        outMap[key] = res;
+      }
+      if (resCount === count) {
+        return callback(errCount, outMap);
+      }
+    };
+
+    if (keyOptions)
+      util._extend(opts, keyOptions);
+
+    if(!value)
+      self[operation](key, opts, cb);
+    else
+      self[operation](key, value, opts, cb);
+  };
+
+  if (Array.isArray(kv)) {
+    // keys -> [key1, key2, key3]
+    for (var index in kv) {
+      single(kv[index]);
+    }
+  } else {
+    // kv -> {key1: {delta: -1, initial: 5}}
+    for (var key in kv) {
+      single(key, kv[key], !extraAttr ? null : (kv[key][extraAttr] || options[extraAttr]));
+    }
+  }
+},
+
+MockBucket.prototype.getMulti = function(keys, options, callback) {
+  this._multi('get', keys, options, callback);
+};
+
+MockBucket.prototype.upsertMulti = function(kv, options, callback) {
+  this._multi('upsert', kv, options, callback, 'value');
+};
+
+MockBucket.prototype.insertMulti = function(kv, options, callback) {
+  this._multi('insert', kv, options, callback, 'value');
+};
+
+MockBucket.prototype.replaceMulti = function(kv, options, callback) {
+  this._multi('replace', kv, options, callback, 'value');
+};
+
+MockBucket.prototype.appendMulti = function(kv, options, callback) {
+  this._multi('append', kv, options, callback, 'fragment');
+};
+
+MockBucket.prototype.prependMulti = function(kv, options, callback) {
+  this._multi('prepend', kv, options, callback, 'fragment');
+};
+
+MockBucket.prototype.counterMulti = function(kv, options, callback) {
+  this._multi('counter', kv, options, callback, 'delta');
+};
+
+MockBucket.prototype.getAndLockMulti = function(keys, options, callback) {
+  this._multi('getAndLock', keys, options, callback);
+};
+
+MockBucket.prototype.unlockMulti = function(kv, options, callback) {
+  this._multi('unlock', kv, options, callback, 'cas');
+};
+
+MockBucket.prototype.touchMulti = function(kv, options, callback) {
+  this._multi('touch', kv, options, callback, 'expiry');
+};
+
+MockBucket.prototype.getAndTouchMulti = function(kv, options, callback) {
+  this._multi('getAndTouch', kv, options, callback, 'expiry');
+};
+
+ MockBucket.prototype.removeMulti = function(keys, options, callback) {
+   this._multi('remove', keys, options, callback);
+ };
 
 Object.defineProperty(MockBucket.prototype, 'lcbVersion', {
   get: function() {

--- a/test/crud.test.js
+++ b/test/crud.test.js
@@ -275,6 +275,27 @@ describe('#crud', function () {
             }));
           }));
         });
+        it('should work with partial failures', function(done) {
+          var key1 = H.key();
+          var key2 = H.key();
+          H.b.insert(key1, 'foo', H.okCallback(function() {
+            H.b.insert(key2, 'bar', H.okCallback(function() {
+              H.b.getAndLockMulti([key2], H.okCallback(function() {
+                H.b.removeMulti([key1, key2], function(err, res) {
+                  assert(err === 1);
+                  assert(res);
+                  assert(res[key1]);
+                  assert(res[key1].cas);
+                  assert(!res[key1].error);
+                  assert(res[key2]);
+                  assert(!res[key2].cas);
+                  assert(res[key2].error);
+                  done();
+                });
+              }));
+            }));
+          }));
+        });
       });
 
       describe('unlock', function () {
@@ -334,6 +355,27 @@ describe('#crud', function () {
             H.b.getAndLock(key, H.okCallback(function(lockRes) {
               H.b.unlock(key, lockRes.cas, function() {
                 H.b.replace(key, 'bar', H.okCallback(function() {
+                  done();
+                }));
+              });
+            }));
+          }));
+        });
+        it('should work with partial failures', function(done) {
+          var kv = {}, key1 = H.key(), key2 = H.key(), key3 = H.key();
+          kv[key1] = {value: 'foo'};
+          kv[key2] = {value: 'bar'};
+          kv[key3] = {value: 'baz'};
+          H.b.insertMulti(kv, H.okCallback(function(res) {
+            H.b.getAndLockMulti([key1, key2, key3], H.okCallback(function(lockRes) {
+              kv = {};
+              kv[key1] = {cas: lockRes[key1].cas};
+              kv[key2] = {cas: lockRes[key2].cas};
+              H.b.unlockMulti(kv, function() {
+                kv = {};
+                kv[key1] = {value: 'bar'};
+                kv[key2] = {value: 'foo'};
+                H.b.replaceMulti(kv, H.okCallback(function() {
                   done();
                 }));
               });
@@ -465,6 +507,26 @@ describe('#crud', function () {
             }));
           }));
         });
+        it('should work with multi', function(done) {
+          var kv = {}, key1 = H.key(), key2 = H.key();
+          kv[key1] = {delta: 1};
+          kv[key2] = {delta: -1, initial: 5};
+          H.b.counterMulti(kv, {initial: 10}, H.okCallback(function() {
+            H.b.counterMulti(kv, function(err, res) {
+              assert.equal(err, 0);
+              assert(res);
+              assert(res[key1]);
+              assert(res[key1].cas);
+              assert.equal(res[key1].value, 11);
+              assert(!res[key1].error);
+              assert(res[key2]);
+              assert(res[key2].cas);
+              assert.equal(res[key2].value, 4);
+              assert(!res[key2].error);
+              done();
+            });
+          }));
+        });
       });
 
       describe('append', function() {
@@ -503,6 +565,32 @@ describe('#crud', function () {
                 assert(err);
                 assert(!res);
                 done();
+              });
+            }));
+          }));
+        });
+        it('should work with multi', function(done) {
+          var kv = {}, key1 = H.key(), key2 = H.key();
+          kv[key1] = {value: 'foo'};
+          kv[key2] = {value: 'foo'};
+          H.b.insertMulti(kv, H.okCallback(function(){
+            H.b.getAndLock(key2, H.okCallback(function() {
+              var kv = {};
+              kv[key1] = {fragment: 'bar'};
+              kv[key2] = {fragment: 'baz'};
+              H.b.appendMulti(kv, function() {
+                H.b.getMulti([key1, key2], H.okCallback(function(res) {
+                  assert(res);
+                  assert(res[key1]);
+                  assert(res[key1].cas);
+                  assert.equal(res[key1].value, 'foobar');
+                  assert(!res[key1].error);
+                  assert(res[key2]);
+                  assert(res[key2].cas);
+                  assert.equal(res[key2].value, 'foo');
+                  assert(!res[key2].error);
+                  done();
+                }));
               });
             }));
           }));
@@ -549,6 +637,32 @@ describe('#crud', function () {
             }));
           }));
         });
+        it('should work with multi', function(done) {
+          var kv = {}, key1 = H.key(), key2 = H.key();
+          kv[key1] = {value: 'foo'};
+          kv[key2] = {value: 'foo'};
+          H.b.insertMulti(kv, H.okCallback(function(){
+            H.b.getAndLock(key2, H.okCallback(function() {
+              var kv = {};
+              kv[key1] = {fragment: 'bar'};
+              kv[key2] = {fragment: 'baz'};
+              H.b.prependMulti(kv, function() {
+                H.b.getMulti([key1, key2], H.okCallback(function(res) {
+                  assert(res);
+                  assert(res[key1]);
+                  assert(res[key1].cas);
+                  assert.equal(res[key1].value, 'barfoo');
+                  assert(!res[key1].error);
+                  assert(res[key2]);
+                  assert(res[key2].cas);
+                  assert.equal(res[key2].value, 'foo');
+                  assert(!res[key2].error);
+                  done();
+                }));
+              });
+            }));
+          }));
+        });
       });
     });
 
@@ -580,6 +694,26 @@ describe('#crud', function () {
           assert.deepEqual(getRes.cas, upsertRes.cas);
           done();
         }))
+      }));
+    });
+
+    it('should successfully upsert some documents', function(done) {
+      var kv = {}, key1 = H.key(), key2 = H.key();
+      kv[key1] = {value: 'foo'};
+      kv[key2] = {value: 'bar'};
+      H.b.upsertMulti(kv, H.okCallback(function(){
+        H.b.getMulti([key1,key2], H.okCallback(function(res) {
+          assert(res);
+          assert(res[key1]);
+          assert(res[key1].cas);
+          assert.equal(res[key1].value, 'foo');
+          assert(!res[key1].error);
+          assert(res[key2]);
+          assert(res[key2].cas);
+          assert.equal(res[key2].value, 'bar');
+          assert(!res[key2].error);
+          done();
+        }));
       }));
     });
 
@@ -677,7 +811,7 @@ describe('#crud', function () {
           }));
         }));
       });
-    }
+    };
     describe('getAndTouch', function() {
       touchTests(function(key, expiry, callback) {
         H.b.getAndTouch(key, expiry, callback);
@@ -686,6 +820,41 @@ describe('#crud', function () {
     describe('touch', function() {
       touchTests(function(key, expiry, callback) {
         H.b.touch(key, expiry, callback);
+      });
+    });
+
+    function touchMultiTests(touchFn) {
+      it('should succesfully update expiry (slow)', function(done) {
+        this.timeout(5000);
+        var kv = {}, key1 = H.key(), key2 = H.key();
+        kv[key1] = {value: 'foo'};
+        kv[key2] = {value: 'bar'};
+        H.b.insertMulti(kv, {expiry: 1}, H.okCallback(function () {
+          touchFn(kv, {expiry: 2}, H.okCallback(function (res) {
+            setTimeout(function () {
+              H.b.getMulti([key1,key2], H.okCallback(function() {
+                setTimeout(function() {
+                  H.b.getMulti([key1,key2], function (err, res) {
+                    assert(err);
+                    assert(res[key1].error);
+                    assert(res[key2].error);
+                    done();
+                  });
+                }, 3000);
+              }));
+            }, 100);
+          }));
+        }));
+      });
+    };
+    describe('getAndTouchMulti', function() {
+      touchMultiTests(function(kv, expiry, callback) {
+        H.b.getAndTouchMulti(kv, expiry, callback);
+      });
+    });
+    describe('touchMulti', function() {
+      touchMultiTests(function(kv, expiry, callback) {
+        H.b.touchMulti(kv, expiry, callback);
       });
     });
 


### PR DESCRIPTION
As explained in [this issue](https://issues.couchbase.com/browse/JSCBC-199) every `multi` method has been removed from couchnode (only `getMulti` still exists). This commit is a proposal to reintroduce them — but only as helpers, this implementation only wraps existing code and do not use libcouchbase directly.

Once in a while, using an `upsertMulti` can be useful, so instead of letting everyone re-implement it all over again, it seems appropriate to offer it with couchnode.

This implementation relies heavily on the previous `getMulti` implementation. A `_multi` method gather every bit of code while each operation (`upsert`, `insert`, `touch`) only calls it with the proper arguments. This `_multi` method handles validation, options (single's options override multi options) and produces a standard output.

The code tries to stick as much as possible to the existing coding standards and a test + a documentation is written for every bit of it.

As an example:
```
bucket.getAndLockMulti([key1, key2, key3], function(err, v) {
  assert(err === 1);
  assert(v[key1].cas);
  assert(v[key1].value);
  assert(!v[key1].cas);
  assert(v[key1].error);
})

var kv = {};
kv[key1] = {value: 'foo'};
kv[key2] = {value: 'bar', expiry: 5};
bucket.upsertMulti(kv, {expiry: 10}, function(err, v) {
  assert(err === 2);
})
```

ps. was not able to submit this via review.couchbase.com, has sign the Contributor Agreement, but got no mail