### PR TITLE
Fix "undefined" error code in couchbase mock

### DIFF
--- a/lib/mock/bucket.js
+++ b/lib/mock/bucket.js
@@ -681,7 +681,7 @@ MockBucket.prototype._store = function(key, value, options, callback, opType) {
       }
       if (origSetItem && !_compareCas(origSetItem.cas, options.cas)) {
         return callback(new CbError(
-            'cas mismatch', key.keyAlreadyExists), null);
+            'cas mismatch', errs.keyAlreadyExists), null);
       }
 
       var encItemSet = this._encodeDoc(value);


### PR DESCRIPTION
In case of CAS mismatch the couchbase mock returns an error with an undefined error code instead of the correct error code. This fixes the typo that causes this issue.