### PR TITLE
Replaced deprecated method references in doc

### DIFF
--- a/lib/bucket.js
+++ b/lib/bucket.js
@@ -1079,7 +1079,7 @@ Bucket.prototype.getAndTouch = function(key, expiry, options, callback) {
  *
  * Once locked, a document can be unlocked either by explicitly calling
  * {@link Bucket#unlock} or by performing a storage operation
- * (e.g. {@link Bucket#set}, {@link Bucket#replace}, {@link Bucket::append})
+ * (e.g. {@link Bucket#upsert}, {@link Bucket#replace}, {@link Bucket::append})
  * with the current CAS value.  Note that any other lock operations on this
  * key will fail while a document is locked.
  *
@@ -1390,8 +1390,8 @@ Bucket.prototype.insert = function(key, value, options, callback) {
 };
 
 /**
- * Identical to {@link Bucket#set}, but will only succeed if the document
- * exists already (i.e. the inverse of {@link Bucket#add}).
+ * Identical to {@link Bucket#upsert}, but will only succeed if the document
+ * exists already (i.e. the inverse of {@link Bucket#insert}).
  *
  * @param {string|Buffer} key
  * The target document key.
@@ -1419,7 +1419,7 @@ Bucket.prototype.replace = function(key, value, options, callback) {
 };
 
 /**
- * Similar to {@link Bucket#set}, but instead of setting a new key,
+ * Similar to {@link Bucket#upsert}, but instead of setting a new key,
  * it appends data to the existing key. Note that this function only makes
  * sense when the stored data is a string; 'appending' to a JSON document may
  * result in parse errors when the document is later retrieved.


### PR DESCRIPTION
A few methods seem to have been deprecated but their documentation was never updated to reflect this.

set should refer to upsert
add should refer to insert