### PR TITLE
remove node-gyp rebuild on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "native": false
   },
   "scripts": {
-    "install": "(node-gyp rebuild 2> builderror.log) || (exit 0)",
     "test": "./node_modules/mocha/bin/mocha"
   }
 }


### PR DESCRIPTION
This is causing problems for us on our production servers because on install of this library, it wipes out the node bindings and rebuilds them which doesn't work because we specifically don't include the compile time libraries on a production server. 