### PR TITLE
Fixing case where 403 is returned without a body.

### DIFF
--- a/lib/clustermgr.js
+++ b/lib/clustermgr.js
@@ -81,8 +81,13 @@ ClusterManager.prototype.listBuckets = function(callback) {
       return callback(err);
     }
     if (resp.statusCode !== 200) {
-      var errData = JSON.parse(data);
-      return callback(new Error(errData.reason), null);
+
+      if (data) {
+        var errData = JSON.parse(data);
+        return callback(new Error(errData.reason), null);
+      }
+
+      return callback(new Error('operation failed (' + resp.statusCode +')'), null);
     }
     var bucketInfo = JSON.parse(data);
     callback(null, bucketInfo);

--- a/test/clustermgr.test.js
+++ b/test/clustermgr.test.js
@@ -20,6 +20,19 @@ describe('#cluster management', function() {
       });
     });
   }
-  describe('#RealBucket', allTests.bind(this, harness));
+  describe('#RealBucket', function() {
+    allTests.bind(this, harness);
+
+    it('should not be able to list buckets with wrong password', function (done) {
+      var cluster = new harness.lib.Cluster(harness.connstr);
+      var clusterMgr = cluster.manager(harness.muser, 'junk');
+      clusterMgr.listBuckets(function (err, list) {
+        assert(err);
+        assert.equal(err.message, 'operation failed (401)');
+        assert(!list);
+        done();
+      });
+    });
+  });
   describe('#MockBucket', allTests.bind(this, harness.mock));
 });


### PR DESCRIPTION
Without the fix, the test I added results in the following error, since JSON.parse doesn't accept an empty string.

```
1) #cluster management #RealBucket should not be able to list buckets with wrong password:
     Uncaught SyntaxError: Unexpected end of input
      at Object.parse (native)
      at lib/clustermgr.js:85:28
      at IncomingMessage.<anonymous> (lib/clustermgr.js:14:7)
      at endReadableNT (_stream_readable.js:893:12)
```