### PR TITLE
Remove dependency jsonparse which no longer seems to be used

### DIFF
--- a/lib/bucket.js
+++ b/lib/bucket.js
@@ -3,7 +3,6 @@
 var util = require('util');
 var fs = require('fs');
 var path = require('path');
-var JsonParser = require('jsonparse');
 var qs = require('querystring');
 var request = require('request');
 var dns = require('dns');

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "name": "couchbase",
   "dependencies": {
     "bindings": "~1.2.1",
-    "jsonparse": "~1.0.0",
     "nan": "~2.0.8",
     "prebuild": "~2.6.0",
     "request": "~2.61.0"


### PR DESCRIPTION
The only require case was in lib/bucket.js, and it was an unused variable. My guess is this was once used, but later replaced by JSON.parse?