### PR TITLE
Handle cases where n1ql doesnt return error details

### DIFF
--- a/lib/bucket.js
+++ b/lib/bucket.js
@@ -654,7 +654,7 @@ Bucket.prototype._n1qlReq = function(host, q, adhoc, emitter) {
       var errStr = val;
       var jsonError = JSON.parse(errStr);
       var err;
-      if (jsonError.errors.length > 0) {
+      if (jsonError && jsonError.errors.length > 0) {
         var firstErr = jsonError.errors[0];
         err = new Error(firstErr.msg);
         err.code = firstErr.code;
@@ -666,10 +666,13 @@ Bucket.prototype._n1qlReq = function(host, q, adhoc, emitter) {
           otherErr.code = nextErr.code;
           err.otherErrors.push(otherErr);
         }
+
+        err.requestID = jsonError.requestID;
       } else {
-        err = new Error('An unknown error occured');
+        err = new Error('An unknown error occured. Error code: ' + errCode);
+        err.errCode = errCode
       }
-      err.requestID = jsonError.requestID;
+
 
       emitter.emit('error', err);
     }


### PR DESCRIPTION
More work is needed for more informative error reporting,
but this fix will at least report the correct error and return code