### PR TITLE
FIX sort order of view entries with compound keys in mock mode

### DIFF
--- a/lib/mock/bucket.js
+++ b/lib/mock/bucket.js
@@ -1288,16 +1288,16 @@ MockBucket.prototype._execView = function(ddoc, name, options, callback) {
 
     if (options.descending) {
       results.sort(function(a,b){
-        if (a.key > b.key) { return -1; }
-        if (a.key < b.key) { return +1; }
+        var compare = cbCompare(b.key, a.key);
+        if (compare != 0) { return compare; }
         if (a.id > b.id) { return -1; }
         if (a.id < b.id) { return +1; }
         return 0;
       });
     } else {
       results.sort(function(a,b){
-        if (b.key > a.key) { return -1; }
-        if (b.key < a.key) { return +1; }
+        var compare = cbCompare(a.key, b.key);
+        if (compare != 0) { return compare; }
         if (b.id > a.id) { return -1; }
         if (b.id < a.id) { return +1; }
         return 0;


### PR DESCRIPTION
The way keys are compared in the Bucket Mock results in a wrong sort order for compound keys with integers. 

In Mock mode I get view results like that:
```
[1,1]
[1,10]
[1,100]
[1,2]
[1,3]
```