### PR TITLE
bucketmgr: fix undefined reference in index creation/deletion

### DIFF
--- a/lib/bucketmgr.js
+++ b/lib/bucketmgr.js
@@ -309,7 +309,7 @@ BucketManager.prototype._createIndex = function(options, callback) {
   if (options.name !== '') {
     qs += ' `' + options.name + '`';
   }
-  qs += ' ON `' + this._bucket.name + '`';
+  qs += ' ON `' + this._bucket._name + '`';
   if (options.fields.length > 0) {
     qs += '(';
     for (var i = 0; i < options.fields.length; ++i) {
@@ -411,9 +411,9 @@ BucketManager.prototype._dropIndex = function(options, callback) {
   var qs = '';
 
   if (!options.name) {
-    qs += 'DROP PRIMARY INDEX `' + this._bucket.name + '`';
+    qs += 'DROP PRIMARY INDEX `' + this._bucket._name + '`';
   } else {
-    qs += 'DROP INDEX `' + this._bucket.name + '`.`' + options.name + '`';
+    qs += 'DROP INDEX `' + this._bucket._name + '`.`' + options.name + '`';
   }
 
   this._bucket.query(N1qlQuery.fromString(qs), function(err) {
@@ -531,7 +531,7 @@ BucketManager.prototype.buildDeferredIndexes = function(callback) {
     }
 
     var qs = '';
-    qs += 'BUILD INDEX ON `' + this._bucket.name + '`(';
+    qs += 'BUILD INDEX ON `' + this._bucket._name + '`(';
     for (var j = 0; j < deferredList.length; ++i) {
       if (j > 0) {
         qs += ', ';


### PR DESCRIPTION
When bucketmgr creates/deletes some indexes, it was using
this._bucket.name where it should have been using this._bucket._name.