### PR TITLE
Updating npm module request@2.79.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "bindings": "~1.2.1",
     "nan": "~2.3.2",
     "prebuild": "~4.1.2",
-    "request": "~2.74.0"
+    "request": "~2.79.0"
   },
   "devDependencies": {
     "ink-docstrap": "git+https://github.com/brett19/docstrap.git#master",


### PR DESCRIPTION
npm WARN deprecated node-uuid@1.4.7: use uuid module instead

request@2.79.0 module is using "uuid": "^3.0.0"