### PR TITLE
prebuild for linux and macos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ config.json
 builderror.log
 configcache.txt
 /coverage/
+/prebuilds

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+os:
+  - linux
+  - osx
+
+dist: trusty
+
+language: node_js
+node_js:
+  - 7
+
+script:
+  - npm install
+  - npm run prebuild-all -- -u "${GITHUB_OAUTH_TOKEN}"
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "mocha": "~3.2.0",
     "nan": "~2.5.1",
     "prebuild": "~6.1.0",
+    "prebuild-install": "~2.1.2",
     "request": "~2.80.0"
   },
   "devDependencies": {
@@ -36,16 +37,17 @@
   },
   "repository": {
     "type": "git",
-    "url": "http://github.com/couchbase/couchnode.git"
+    "url": "http://github.com/stelcheck/couchnode.git"
   },
   "version": "2.3.3",
   "config": {
     "native": false
   },
   "scripts": {
-    "install": "prebuild --install",
+    "install": "prebuild-install || prebuild --compile",
     "test": "mocha",
     "rebuild": "prebuild --compile",
-    "prebuild": "prebuild --verbose --strip"
+    "prebuild": "prebuild --verbose --strip",
+    "prebuild-all": "prebuild --all"
   }
 }


### PR DESCRIPTION
For some reason, this project uses prebuilds but not prebuild-install
to download the builds from GitHub. This commit solves the issue
for *nix platforms (windows support to come at a later time).

Note that the repository in `package.json` has been changed to
my personal one, so that I may test building on my own repo.

You can test this by running the following:

```shell
npm install stelcheck/couchnode#v2.3.3-prebuild
```

Also note that this also mean that you will either want to create a develop branch and push releases to master, or that you will want to rename the version in `package.json` for non-official releases (so not to overwrite the dependencies being uploaded to GitHub).