### PR TITLE
Temporary fix for prebuild-install

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "name": "couchbase",
   "dependencies": {
     "bindings": "~1.2.1",
-    "mocha": "~3.2.0",
     "nan": "~2.5.1",
     "prebuild-install": "^2.1.2",
     "request": "~2.80.0"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "url": "http://github.com/couchbase/couchnode.git"
   },
   "version": "2.3.3",
+  "_from": "Having this set to something more than 4 characters fixes a bug in prebuild-install",
   "config": {
     "native": false
   },


### PR DESCRIPTION
I noticed recently that prebuild-install was causing a node-gyp build every time when installing Couchbase, even when the prebuilds were available, even when targeting `couchbase/couchnode#c5f933bd6c845bcad6bf85df11a5e8250aaa72e0`.

Example: `pnpm install couchbase/couchnode#c5f933bd6c845bcad6bf85df11a5e8250aaa72e0`

### Before
```
  github.com/couchbase/couchnode/c5f933bd6c845bcad6bf85df11a5e8250aaa72e0  $ npm run install  
  github.com/couchbase/couchnode/c5f933bd6c845bcad6bf85df11a5e8250aaa72e0  > couchbase@2.3.3 install /Users/ahorner/Desktop/xxx/node_modules/.github.com/couchbase/couchnode/c5f933bd6c845bcad6bf85df11a5e8250aaa72e0/node_modules/couchbase  
  github.com/couchbase/couchnode/c5f933bd6c845bcad6bf85df11a5e8250aaa72e0  > prebuild-install || node-gyp rebuild  
  github.com/couchbase/couchnode/c5f933bd6c845bcad6bf85df11a5e8250aaa72e0! prebuild-install info begin Prebuild-install version 2.1.2  
  github.com/couchbase/couchnode/c5f933bd6c845bcad6bf85df11a5e8250aaa72e0! prebuild-install info install installing inside prebuild-install directory, skipping download. 
```

I'm not exactly sure what the proper fix is (probably a change to prebuild-install) but this solution seems to work for me.

### After
```
prebuild-install info begin Prebuild-install version 2.1.2
prebuild-install info looking for local prebuild @ prebuilds/couchbase-v2.3.3-node-v51-darwin-x64.tar.gz
prebuild-install info looking for cached prebuild @ /Users/ahorner/.npm/_prebuilds/https-github.com-couchbase-couchnode-releases-download-v2.3.3-couchbase-v2.3.3-node-v51-darwin-x64.tar.gz
prebuild-install info found cached prebuild 
prebuild-install info unpacking @ /Users/ahorner/.npm/_prebuilds/https-github.com-couchbase-couchnode-releases-download-v2.3.3-couchbase-v2.3.3-node-v51-darwin-x64.tar.gz
prebuild-install info unpack resolved to /Users/ahorner/Desktop/xxx/node_modules/.github.com/couchbase/couchnode/c5f933bd6c845bcad6bf85df11a5e8250aaa72e0/node_modules/couchbase/build/Release/couchbase_impl.node
prebuild-install info unpack required /Users/ahorner/Desktop/xxx/node_modules/.github.com/couchbase/couchnode/c5f933bd6c845bcad6bf85df11a5e8250aaa72e0/node_modules/couchbase/build/Release/couchbase_impl.node successfully
prebuild-install info install Prebuild successfully installed!
```

### Related change
https://github.com/mafintosh/prebuild-install/pull/12/files#diff-13198ad72a3472842248bc3d0f0d3fd7R43

### Related issues
- https://github.com/mafintosh/prebuild-install/issues/8
- https://github.com/mafintosh/prebuild-install/issues/15