### PR TITLE
Removes mocha as a dependency (leaves it as a devDep)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "name": "couchbase",
   "dependencies": {
     "bindings": "~1.2.1",
-    "mocha": "~3.2.0",
     "nan": "~2.5.1",
     "prebuild-install": "~2.1.2",
     "request": "~2.80.0"


### PR DESCRIPTION
Mocha is getting installed as a production dependency, when I assume it shouldn't be. It is already mentioned as a devDependency.