### PR TITLE
 provided security fixes by updating the request library

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "bindings": "~1.2.1",
     "nan": "~2.5.1",
     "prebuild-install": "~2.1.2",
-    "request": "~2.80.0"
+    "request": "~2.83.0"
   },
   "devDependencies": {
     "ink-docstrap": "git+https://github.com/brett19/docstrap.git#master",


### PR DESCRIPTION
Fixing the below security issues.

Hawk before 3.1.3 and 4.x before 4.1.1 allow remote attackers to cause a denial of service (CPU consumption or partial outage) via a long (1) header or (2) URI that is matched against an improper regular expression.
