### PR TITLE
FIX: dropPrimaryIndex crashes when options not given

### DIFF
--- a/lib/bucketmgr.js
+++ b/lib/bucketmgr.js
@@ -510,7 +510,7 @@ BucketManager.prototype.dropIndex = function(indexName, options, callback) {
  */
 BucketManager.prototype.dropPrimaryIndex = function(options, callback) {
   if (options instanceof Function) {
-    callback = arguments[1];
+    callback = arguments[0];
     options = undefined;
   }
   if (!options) {


### PR DESCRIPTION
It was trying to pick up the wrong argument.