### PR TITLE
Fix query running in the vm sandbox

### DIFF
--- a/lib/bucket.js
+++ b/lib/bucket.js
@@ -1395,7 +1395,7 @@ Bucket.prototype._fts = function(query, callback) {
  * @committed
  */
 Bucket.prototype.query = function(query, params, callback) {
-  if (params instanceof Function) {
+  if (typeof params === 'function') {
     callback = arguments[1];
     params = undefined;
   }

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2,6 +2,7 @@
 
 var assert = require('assert');
 var harness = require('./harness.js');
+var vm = require('vm')
 
 var Vq = harness.lib.ViewQuery;
 
@@ -287,7 +288,15 @@ describe('#Querying', function() {
               done();
             });
         });
+
+      it('view queries should work with callback in the nodejs vm sandbox',
+        function(done) {
+          vm.runInNewContext(`bucket.query(query, function (err, res) {
+            done(err)
+          })`, { bucket: H.b, query: Vq.from(ddKey, 'simple'), done })          
+        });
     });
+    
   }
 
   describe('#RealBucket', allTests.bind(this, harness));


### PR DESCRIPTION
The basic query hangs if it is executed through nodejs [vm](https://nodejs.org/api/vm.html) sandbox.
The problem is that the driver uses this code to verify if parameter is callback
```js
if (params instanceof Function) 
```

This gives false for function in the vm sandbox. See this described [here](https://github.com/nodejs/node-v0.x-archive/issues/1277).
The correct way for checking if the parameter is function is this
```js
if (typeof params === 'function') {
```

I submitted the fix in one place and also test. Unfortunately it hangs when it runs with mocks. I was not able to find out why.

