### PR TITLE
Fixed Geospatial Queries

### DIFF
--- a/lib/searchquery_queries.js
+++ b/lib/searchquery_queries.js
@@ -1129,8 +1129,8 @@ TermRangeQuery.prototype.toJSON = QueryBase.prototype.toJSON;
  */
 function GeoDistanceQuery(lat, lon, distance) {
   this.data = {
-    location: [lat, lon],
-    distance: [distance]
+    location: {lat, lon},
+    distance: distance
   };
 }
 SearchQuery.GeoDistanceQuery = GeoDistanceQuery;

--- a/lib/searchquery_sort.js
+++ b/lib/searchquery_sort.js
@@ -187,7 +187,7 @@ function GeoDistanceSort(field, lat, lon) {
   this.data = {
     by: 'geo_distance',
     field: field,
-    location: [lon, lat]
+    location: {lon, lat}
   };
 }
 SearchSort.GeoDistanceSort = GeoDistanceSort;


### PR DESCRIPTION
According to https://docs.couchbase.com/server/6.0/fts/fts-geospatial-queries.html#specifying-distances Radius-Based is like following

```json
{
  "from": 0,
  "size": 10,
  "query": {
    "location": {
      "lon": -2.235143,
      "lat": 53.482358
     },
      "distance": "100mi",
      "field": "geo"
    },
  "sort": [
    {
      "by": "geo_distance",
      "field": "geo",
      "unit": "mi",
      "location": {
      "lon": -2.235143,
      "lat": 53.482358
      }
    }
  ]
}
````