### PR TITLE
Add a short CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+A concise changelog is maintained at [docs.couchbase.com/nodejs-sdk](https://docs.couchbase.com/nodejs-sdk/current/project-docs/sdk-release-notes.html).


### PR DESCRIPTION
Developers might land at the repository without considering an external documentation portal containing a CHANGELOG as most packages have that included as part of their core repository.