### PR TITLE
Fix to debug module memory leak when used in dynamic context

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -5,6 +5,7 @@ const binding = require('./binding');
 const connstr = require('./connstr');
 const PromiseHelper = require('./promisehelper');
 const debug = require('debug')('couchnode:lcb');
+const debugSeverityLoggers = Object.assign({}, ...['trace','debug','info','warn','error','fatal'].map(severity => ({[severity]: debug.extend(severity)})));
 
 function _logSevToStr(severity) {
   switch (severity) {
@@ -27,7 +28,7 @@ function _logSevToStr(severity) {
 function _logToDebug(info) {
   var severity = _logSevToStr(info.severity);
   var location = info.srcFile + ':' + info.srcLine;
-  debug.extend(severity)(
+  debugSeverityLoggers[severity](
     '(' + info.subsys + ' @ ' + location + ') ' + info.message
   );
 }


### PR DESCRIPTION
The debug module should not be used in dynamic contexts, as it is affected from a memory leak bug visionmedia/debug#678, and more becouse even when the bug will be patched it still add unneccessary operations under the hood.

This patch solve the issue.