### PR TITLE
Fixing compatibility issue with couchbase server 6.5

### DIFF
--- a/lib/bucketmanager.ts
+++ b/lib/bucketmanager.ts
@@ -378,7 +378,7 @@ export class BucketSettings implements IBucketSettings {
       evictionPolicy: data.evictionPolicy,
       maxExpiry: data.maxTTL,
       compressionMode: data.compressionMode,
-      minimumDurabilityLevel: nsServerStrToDuraLevel(data.durabilityMinLevel),
+      minimumDurabilityLevel: nsServerStrToDuraLevel(data.durabilityMinLevel || "none"),
       maxTTL: 0,
       durabilityMinLevel: '',
       ejectionMethod: '',


### PR DESCRIPTION
The /pools/default/buckets read from couchbase server 6.5 does not contain the property durabilityMinLevel, so getAllBuckets returns an "invalid durability level string" error.